### PR TITLE
Fix/shutdown policy engine

### DIFF
--- a/docs/SHUTDOWN_POLICY_RELEASE_CHECKLIST.md
+++ b/docs/SHUTDOWN_POLICY_RELEASE_CHECKLIST.md
@@ -22,12 +22,17 @@ changes.
 - UPS online with low battery shows no shutdown countdown by default.
 - UPS on battery with low battery starts the configured battery countdown.
 - Power restoration cancels the normal battery countdown.
-- `OL FSD` starts and preserves the FSD countdown.
+- `OL FSD` starts and preserves the FSD countdown, including after a settings save.
 - Dismissing the FSD overlay follows the explicit FSD dismiss behavior.
 - Runtime remaining template triggers only while on battery.
 - Communication loss while online does not shut down by default.
 - Communication loss after previously-on-battery state triggers only when the
   fail-safe rule is enabled.
+- Advanced mode rejects `cancelShutdownCountdown` rules unless Allow FSD
+  auto-cancel is enabled.
+- Upgrading from a pre-policy build applies the documented immediate-shutdown
+  disclosure and the Allow immediate shutdown setting matches the migrated
+  legacy behavior.
 - The simulator explains both matched and unmatched rules.
 - Decision history records warning, countdown, cancellation, execution, and
   failure entries.

--- a/docs/SHUTDOWN_POLICY_USER_GUIDE.md
+++ b/docs/SHUTDOWN_POLICY_USER_GUIDE.md
@@ -7,6 +7,25 @@ active countdown.
 
 The policy editor is in Settings under Shutdown Policy.
 
+## Upgrading from Legacy Settings
+
+Existing battery and FSD settings migrate automatically to shutdown policy
+rules on first launch after upgrade.
+
+If your old configuration had `battery.shutdownEnabled = true` and
+`battery.criticalShutdownAlertEnabled = false`, the migration also enables
+Allow immediate shutdown so the upgraded policy keeps the same quiet-shutdown
+behavior. You can review or change that in Settings > Shutdown Policy >
+Advanced > Safety.
+
+The default hold times were also raised from `0` seconds to short non-zero
+values to suppress single-poll glitches: battery warning waits 5 seconds,
+battery shutdown waits 10 seconds, FSD waits 3 seconds, the runtime rule
+template waits 10 seconds, and the communication-loss fail-safe waits 5
+seconds after its `secondsOnBattery >= 60` and poll-loss thresholds are both
+met. See the [release notice](SHUTDOWN_POLICY_RELEASE_NOTICE.md) for the full
+upgrade table.
+
 ## Simple Mode
 
 Simple mode is the recommended mode for most installations. It keeps the same
@@ -32,6 +51,10 @@ token. When enabled, the default FSD rule starts a shutdown countdown as soon as
 FSD is seen. The FSD rule has higher priority than ordinary battery rules and is
 not cancelled just because the UPS also reports online status.
 
+Saving settings while an FSD countdown is active does not clear that countdown.
+The overlay and shutdown state stay active until the configured FSD behavior is
+resolved.
+
 ## Communication-Loss Fail-Safe
 
 The communication-loss rule is available but disabled by default. When enabled,
@@ -42,6 +65,22 @@ Use this only when loss of NUT communication during an outage should be treated
 as unsafe. The rule uses normalized connection state and
 `connection.secondsSinceLastSuccessfulPoll`, so it is independent of raw NUT
 variable names.
+
+The fail-safe also tracks stale telemetry more reliably during an outage. If
+polling still reports `connected` but UPS status has stopped updating beyond the
+grace window, the previously-on-battery timing continues instead of resetting to
+zero.
+
+## Advanced Safety Settings
+
+Advanced mode includes safety toggles that gate the riskiest actions.
+
+- Allow immediate shutdown is off by default unless migration preserved a
+  legacy quiet-shutdown setup.
+- Rules that use `cancelShutdownCountdown` are rejected unless Allow FSD
+  auto-cancel is enabled.
+- FSD remains higher priority than ordinary battery rules and is not cancelled
+  just because the UPS also reports online status.
 
 ## Runtime Remaining Rules
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -281,6 +281,7 @@
         "shutdownPolicyMode": "Policy mode",
         "shutdownPolicySimple": "Simple recommended policy",
         "shutdownPolicyAdvanced": "Advanced custom policy",
+        "shutdownPolicyAdvancedWarning": "Switching to advanced mode keeps the generated simple rules and lets you edit them directly.",
         "policyCommunicationLossEnable": "Shutdown if communication is lost while previously on battery",
         "policyCommunicationLossAfter": "Communication lost after (sec)",
         "policyCountdownSeconds": "Countdown (sec)",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -281,6 +281,7 @@
         "shutdownPolicyMode": "策略模式",
         "shutdownPolicySimple": "简单推荐策略",
         "shutdownPolicyAdvanced": "高级自定义策略",
+        "shutdownPolicyAdvancedWarning": "切换到高级模式后会保留当前生成的简单模式规则，并允许你直接编辑它们。",
         "policyCommunicationLossEnable": "在电池供电期间通信丢失时关机",
         "policyCommunicationLossAfter": "通信丢失时间（秒）",
         "policyCountdownSeconds": "倒计时（秒）",

--- a/src/main/config/configSchema.test.ts
+++ b/src/main/config/configSchema.test.ts
@@ -88,7 +88,7 @@ describe('shutdown policy config schema', () => {
     expect(defaultAppConfig.shutdownPolicy.version).toBe(1);
     expect(defaultAppConfig.shutdownPolicy.mode).toBe('simple');
     expect(defaultAppConfig.shutdownPolicy.safety).toEqual({
-      requireHoldForShutdownSeconds: 0,
+      requireHoldForShutdownSeconds: 5,
       maxCountdownSeconds: 300,
       allowImmediateShutdown: false,
       allowFsdAutoCancel: false,
@@ -124,7 +124,7 @@ describe('shutdown policy config schema', () => {
 
     const result = applyConfigPatch(defaultAppConfig, patch);
     expect(result.shutdownPolicy.safety.maxCountdownSeconds).toBe(120);
-    expect(result.shutdownPolicy.safety.requireHoldForShutdownSeconds).toBe(0);
+    expect(result.shutdownPolicy.safety.requireHoldForShutdownSeconds).toBe(5);
   });
 
   it('rebuilds simple battery policy patches into valid engine-driven rules', () => {

--- a/src/main/shutdown/ShutdownPolicyContextBuilder.test.ts
+++ b/src/main/shutdown/ShutdownPolicyContextBuilder.test.ts
@@ -57,6 +57,26 @@ describe('ShutdownPolicyContextBuilder', () => {
     expect(context.connection.state).toBe('degraded');
   });
 
+  it('continues advancing secondsOnBattery when status is stale beyond grace even if connectionState stays connected', () => {
+    const builder = new ShutdownPolicyContextBuilder({
+      statusStaleGraceSeconds: 15,
+    });
+
+    builder.build({
+      rawUpsStatus: 'OB DISCHRG',
+      connectionState: 'connected',
+      now: 0,
+    });
+    const context = builder.build({
+      rawUpsStatus: null,
+      connectionState: 'connected',
+      now: 20000,
+    });
+
+    expect(context.connection.state).toBe('degraded');
+    expect(context.state.secondsOnBattery).toBe(20);
+  });
+
   it('tracks duration transitions from OB to OL', () => {
     const builder = new ShutdownPolicyContextBuilder();
 
@@ -112,5 +132,16 @@ describe('ShutdownPolicyContextBuilder', () => {
     expect(context.connection.state).toBe('degraded');
     expect(context.connection.secondsSinceLastSuccessfulPoll).toBe(310);
     expect(context.state.secondsOnBattery).toBe(370);
+  });
+
+  it('clamps out-of-order timestamps so duration tracking does not rewind', () => {
+    const builder = new ShutdownPolicyContextBuilder();
+
+    builder.build({ rawUpsStatus: 'OB', now: 10000 });
+    const rewindContext = builder.build({ rawUpsStatus: 'OB', now: 9000 });
+    const context = builder.build({ rawUpsStatus: 'OB', now: 11000 });
+
+    expect(rewindContext.now).toBe(10000);
+    expect(context.state.secondsOnBattery).toBe(1);
   });
 });

--- a/src/main/shutdown/ShutdownPolicyContextBuilder.ts
+++ b/src/main/shutdown/ShutdownPolicyContextBuilder.ts
@@ -50,7 +50,12 @@ export class ShutdownPolicyContextBuilder {
   }
 
   public build(input: ShutdownPolicyContextBuilderInput): ShutdownPolicyContext {
-    const now = input.now ?? Date.now();
+    const reportedNow = input.now ?? Date.now();
+    // Keep time monotonic across build calls so stale or out-of-order caller
+    // timestamps do not rewind duration tracking.
+    const now = this.lastContextNow === null
+      ? reportedNow
+      : Math.max(this.lastContextNow, reportedNow);
     const values = input.values ?? {};
     const rawStatusTokens = parseUpsStatusTokens(input.rawUpsStatus);
     const hasFreshStatus = rawStatusTokens.length > 0;
@@ -103,7 +108,7 @@ export class ShutdownPolicyContextBuilder {
     const wasLastKnownOnBattery = this.lastKnownStatusTokens.includes('OB');
     const assumePreviouslyOnBatteryDuringConnectionLoss =
       !hasFreshStatus &&
-      baseConnectionState !== 'connected' &&
+      !canUseStaleStatus &&
       wasLastKnownOnBattery;
 
     this.secondsOnBattery = advanceDuration(

--- a/src/main/shutdown/ShutdownPolicyDecisionResolver.ts
+++ b/src/main/shutdown/ShutdownPolicyDecisionResolver.ts
@@ -2,8 +2,11 @@ import type {
   ConditionEvaluationResult,
   ShutdownPolicyDecision,
   ShutdownPolicyRule,
-  ShutdownPolicySeverity,
 } from '../../shared/shutdownPolicy/types';
+import {
+  compareShutdownPolicyRank,
+  compareShutdownPolicyRuleResults,
+} from '../../shared/shutdownPolicy/ordering';
 import type { ActiveShutdownCountdown } from './ShutdownPolicyRuntimeState';
 
 export type ShutdownPolicyDecisionCandidate = {
@@ -11,13 +14,6 @@ export type ShutdownPolicyDecisionCandidate = {
   order: number;
   decision: ShutdownPolicyDecision;
   triggerResult: ConditionEvaluationResult;
-};
-
-const severityRank: Record<ShutdownPolicySeverity, number> = {
-  info: 0,
-  warning: 1,
-  critical: 2,
-  forced: 3,
 };
 
 export function resolveShutdownPolicyDecision(
@@ -38,36 +34,23 @@ export function compareShutdownPolicyDecisionRank(
   left: ShutdownPolicyDecisionCandidate,
   right: ShutdownPolicyDecisionCandidate,
 ): number {
-  if (left.rule.priority !== right.rule.priority) {
-    return left.rule.priority - right.rule.priority;
-  }
-
-  const leftSeverity = severityRank[left.rule.severity];
-  const rightSeverity = severityRank[right.rule.severity];
-  if (leftSeverity !== rightSeverity) {
-    return leftSeverity - rightSeverity;
-  }
-
-  if (left.order !== right.order) {
-    return right.order - left.order;
-  }
-
-  return 0;
+  return compareShutdownPolicyRuleResults(left, right);
 }
 
 export function candidateOutranksActiveCountdown(
   candidate: ShutdownPolicyDecisionCandidate,
   activeCountdown: ActiveShutdownCountdown,
 ): boolean {
-  if (candidate.rule.priority !== activeCountdown.priority) {
-    return candidate.rule.priority > activeCountdown.priority;
-  }
-
-  const candidateSeverity = severityRank[candidate.rule.severity];
-  const activeSeverity = severityRank[activeCountdown.severity];
-  if (candidateSeverity !== activeSeverity) {
-    return candidateSeverity > activeSeverity;
-  }
-
-  return candidate.order < activeCountdown.order;
+  return compareShutdownPolicyRank(
+    {
+      priority: candidate.rule.priority,
+      severity: candidate.rule.severity,
+      order: candidate.order,
+    },
+    {
+      priority: activeCountdown.priority,
+      severity: activeCountdown.severity,
+      order: activeCountdown.order,
+    },
+  ) > 0;
 }

--- a/src/main/shutdown/ShutdownPolicyEngine.test.ts
+++ b/src/main/shutdown/ShutdownPolicyEngine.test.ts
@@ -405,6 +405,67 @@ describe('ShutdownPolicyEngine', () => {
       },
     });
   });
+
+  // L5-B2 (Phase 0) — when the engine returns a cancellation decision via the
+  // active-countdown cancelWhen path, the cancelling rule's cooldown must be
+  // recorded; otherwise the same trigger immediately re-arms the countdown.
+  it('applies cooldown to the cancelled rule when an active countdown is cancelled via cancelWhen', () => {
+    const engine = new ShutdownPolicyEngine(makeConfig([
+      makeRule({
+        id: 'battery-countdown-with-cooldown',
+        priority: 100,
+        severity: 'critical',
+        trigger: {
+          all: [
+            { field: 'ups.onBattery', op: 'eq', value: true },
+            { field: 'battery.chargePercent', op: 'lte', value: 20 },
+          ],
+        },
+        action: {
+          type: 'startShutdownCountdown',
+          countdownSeconds: 60,
+          method: 'shutdown',
+        },
+        cancelWhen: {
+          all: [
+            { field: 'ups.online', op: 'eq', value: true },
+            { field: 'ups.fsd', op: 'eq', value: false },
+          ],
+        },
+        cooldownSeconds: 30,
+      }),
+    ]));
+
+    // t=0: low battery on battery — countdown starts
+    expect(engine.evaluate(makeContext({
+      now: 0,
+      battery: { chargePercent: 10 },
+    })).type).toBe('startShutdownCountdown');
+
+    // t=1000: power returns — cancelWhen matches, cancellation returned
+    expect(engine.evaluate(makeContext({
+      now: 1000,
+      ups: {
+        online: true,
+        onBattery: false,
+        lowBattery: false,
+        fsd: false,
+        statusTokens: ['OL'],
+      },
+    })).type).toBe('cancelShutdownCountdown');
+
+    // t=2000: trigger matches again but rule is in cooldown — no decision
+    expect(engine.evaluate(makeContext({
+      now: 2000,
+      battery: { chargePercent: 10 },
+    }))).toEqual({ type: 'none' });
+
+    // t=32000: cooldown elapsed (1000 + 30s = 31000) — countdown can re-arm
+    expect(engine.evaluate(makeContext({
+      now: 32_000,
+      battery: { chargePercent: 10 },
+    })).type).toBe('startShutdownCountdown');
+  });
 });
 
 function makeConfig(rules: ShutdownPolicyRule[]): ShutdownPolicyConfig {

--- a/src/main/shutdown/ShutdownPolicyEngine.ts
+++ b/src/main/shutdown/ShutdownPolicyEngine.ts
@@ -48,6 +48,10 @@ export class ShutdownPolicyEngine {
         candidateOutranksActiveCountdown(selected, activeCountdown);
 
       if (!selectedCanOverride) {
+        // Apply cooldown bookkeeping for the rule whose countdown is being cancelled
+        // BEFORE returning. Otherwise its lastDecisionAt/cooldownUntil are never set
+        // and a still-matching trigger could immediately re-arm the countdown.
+        this.markCancelledRuleDecision(activeCountdown.ruleId, context.now);
         this.runtimeState.clearActiveCountdown();
         return cancellation;
       }
@@ -133,6 +137,17 @@ export class ShutdownPolicyEngine {
       ruleId: activeCountdown.ruleId,
       reason: result.reason,
     };
+  }
+
+  private markCancelledRuleDecision(ruleId: string, now: number): void {
+    // The rule whose countdown was just cancelled deserves the same cooldown treatment
+    // as a rule whose decision was acted on: record lastDecisionAt and (if cooldownSeconds
+    // is configured) arm the cooldown window so the same trigger does not immediately re-fire.
+    const rule = this.config.rules.find((candidate) => candidate.id === ruleId);
+    if (!rule) {
+      return;
+    }
+    this.runtimeState.markRuleDecision(rule.id, now, rule.cooldownSeconds);
   }
 
   private markSelectedDecision(

--- a/src/main/shutdown/ShutdownPolicyEngine.ts
+++ b/src/main/shutdown/ShutdownPolicyEngine.ts
@@ -81,6 +81,11 @@ export class ShutdownPolicyEngine {
     this.runtimeState.reset();
   }
 
+  public releaseFailedDecision(ruleId: string): void {
+    this.runtimeState.clearRuleDecision(ruleId);
+    this.runtimeState.clearActiveCountdown(ruleId);
+  }
+
   private evaluateRules(
     context: ShutdownPolicyContext,
   ): ShutdownPolicyDecisionCandidate[] {

--- a/src/main/shutdown/ShutdownPolicyMigration.test.ts
+++ b/src/main/shutdown/ShutdownPolicyMigration.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   DEFAULT_BATTERY_SHUTDOWN_RULE_ID,
   DEFAULT_FSD_SHUTDOWN_RULE_ID,
@@ -35,7 +35,7 @@ describe('migrateLegacyShutdownPolicyConfig', () => {
     );
 
     expect(policy.mode).toBe('simple');
-    expect(policy.safety.requireHoldForShutdownSeconds).toBe(0);
+    expect(policy.safety.requireHoldForShutdownSeconds).toBe(5);
     expect(batteryRule?.enabled).toBe(true);
     expect(batteryRule?.action).toEqual({
       type: 'startShutdownCountdown',
@@ -136,6 +136,76 @@ describe('migrateLegacyShutdownPolicyConfig', () => {
       type: 'shutdownNow',
       method: 'sleep',
     });
+  });
+
+  it('falls back to migrated defaults when an existing advanced policy no longer satisfies the schema', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    try {
+      const migrated = migrateLegacyShutdownPolicyConfig(
+        {
+          battery: {
+            warningPct: 40,
+            shutdownPct: 20,
+            warningToastEnabled: true,
+            shutdownEnabled: true,
+            criticalAlertEnabled: true,
+            criticalShutdownAlertEnabled: true,
+            shutdownCountdownSeconds: 60,
+            shutdownMethod: 'shutdown',
+          },
+          fsd: {
+            shutdownEnabled: true,
+            shutdownDelaySeconds: 30,
+            shutdownMethod: 'shutdown',
+            overlayEnabled: true,
+          },
+        },
+        {
+          version: 1,
+          mode: 'advanced',
+          safety: {
+            requireHoldForShutdownSeconds: 0,
+            maxCountdownSeconds: 300,
+            allowImmediateShutdown: false,
+            allowFsdAutoCancel: false,
+          },
+          rules: [
+            {
+              id: 'invalid-advanced-rule',
+              name: 'Invalid advanced rule',
+              enabled: true,
+              priority: 100,
+              severity: 'critical',
+              trigger: { field: 'ups.onBattery', op: 'eq', value: true },
+              holdForSeconds: 0,
+              action: {
+                type: 'startShutdownCountdown',
+                countdownSeconds: 60,
+                method: 'shutdown',
+              },
+              createdBy: 'user',
+            },
+          ],
+        },
+      );
+
+      expect(migrated.rules.find((rule) => rule.id === 'invalid-advanced-rule')).toBeUndefined();
+      expect(migrated.safety.requireHoldForShutdownSeconds).toBe(5);
+      expect(migrated.rules.find((rule) =>
+        rule.id === DEFAULT_BATTERY_SHUTDOWN_RULE_ID,
+      )?.action).toEqual({
+        type: 'startShutdownCountdown',
+        countdownSeconds: 60,
+        method: 'shutdown',
+      });
+      expect(warn).toHaveBeenCalledWith(
+        '[ShutdownPolicyMigration] Existing advanced policy failed schema validation; falling back to migrated simple policy.',
+        expect.any(Object),
+      );
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it('does not overwrite existing advanced policies', () => {

--- a/src/main/shutdown/ShutdownPolicyMigration.ts
+++ b/src/main/shutdown/ShutdownPolicyMigration.ts
@@ -3,13 +3,22 @@ import {
   type LegacyShutdownPolicyInput,
 } from '../../shared/shutdownPolicy/defaultPolicies';
 import type { ShutdownPolicyConfig } from '../../shared/shutdownPolicy/types';
+import { shutdownPolicySchema } from './schema/shutdownPolicySchema';
 
 export function migrateLegacyShutdownPolicyConfig(
   legacyConfig: LegacyShutdownPolicyInput,
   existingPolicy?: ShutdownPolicyConfig,
 ): ShutdownPolicyConfig {
   if (existingPolicy?.mode === 'advanced' && existingPolicy.rules.length > 0) {
-    return existingPolicy;
+    const parsed = shutdownPolicySchema.safeParse(existingPolicy);
+    if (parsed.success) {
+      return existingPolicy;
+    }
+
+    console.warn(
+      '[ShutdownPolicyMigration] Existing advanced policy failed schema validation; falling back to migrated simple policy.',
+      parsed.error.flatten(),
+    );
   }
 
   return createSimpleShutdownPolicyConfig(

--- a/src/main/shutdown/ShutdownPolicyRuntimeState.ts
+++ b/src/main/shutdown/ShutdownPolicyRuntimeState.ts
@@ -68,8 +68,22 @@ export class ShutdownPolicyRuntimeState {
     this.activeCountdown = countdown;
   }
 
-  public clearActiveCountdown(): void {
+  public clearActiveCountdown(ruleId?: string): void {
+    if (ruleId !== undefined && this.activeCountdown?.ruleId !== ruleId) {
+      return;
+    }
+
     this.activeCountdown = null;
+  }
+
+  public clearRuleDecision(ruleId: string): void {
+    const state = this.ruleStates.get(ruleId);
+    if (!state) {
+      return;
+    }
+
+    state.lastDecisionAt = undefined;
+    state.cooldownUntil = undefined;
   }
 
   private getRuleState(ruleId: string): ShutdownPolicyRuleRuntimeState {

--- a/src/main/shutdown/schema/policyConditionSchema.ts
+++ b/src/main/shutdown/schema/policyConditionSchema.ts
@@ -177,9 +177,19 @@ function validateConditionLeaf(
 }
 
 export function conditionContainsFsdTrigger(condition: PolicyCondition): boolean {
-  return conditionHasPositiveLeaf(condition, (leaf) =>
-    leaf.field === 'ups.fsd' && leaf.op === 'eq' && leaf.value === true,
-  );
+  if ('all' in condition) {
+    return condition.all.some((child) => conditionContainsFsdTrigger(child));
+  }
+
+  if ('any' in condition) {
+    return condition.any.some((child) => conditionContainsFsdTrigger(child));
+  }
+
+  if ('not' in condition) {
+    return conditionContainsFsdReference(condition.not);
+  }
+
+  return condition.field === 'ups.fsd' && condition.op === 'eq' && condition.value === true;
 }
 
 export function conditionContainsSafeShutdownTrigger(
@@ -240,4 +250,20 @@ function conditionHasPositiveLeaf(
   }
 
   return predicate(condition);
+}
+
+function conditionContainsFsdReference(condition: PolicyCondition): boolean {
+  if ('all' in condition) {
+    return condition.all.some((child) => conditionContainsFsdReference(child));
+  }
+
+  if ('any' in condition) {
+    return condition.any.some((child) => conditionContainsFsdReference(child));
+  }
+
+  if ('not' in condition) {
+    return conditionContainsFsdReference(condition.not);
+  }
+
+  return condition.field === 'ups.fsd';
 }

--- a/src/main/shutdown/schema/shutdownPolicySchema.test.ts
+++ b/src/main/shutdown/schema/shutdownPolicySchema.test.ts
@@ -188,6 +188,60 @@ describe('shutdownPolicySchema', () => {
     const result = shutdownPolicySchema.safeParse(config);
     expect(result.success).toBe(false);
   });
+
+  // L2-F1 (Phase 0) — schema-level defense in depth: user-authored rules whose
+  // action emits cancelShutdownCountdown can otherwise silently abort an active
+  // FSD shutdown via BatterySafetyService.cancelPolicyCountdown.
+  it('rejects user-created cancelShutdownCountdown rules when allowFsdAutoCancel is false', () => {
+    const config = makeConfig([
+      makeRule({
+        id: 'user-cancel-on-online',
+        action: { type: 'cancelShutdownCountdown' },
+        cancelWhen: undefined,
+        trigger: { field: 'ups.online', op: 'eq', value: true },
+      }),
+    ]);
+
+    const result = shutdownPolicySchema.safeParse(config);
+    expect(result.success).toBe(false);
+  });
+
+  it('allows user-created cancelShutdownCountdown rules when allowFsdAutoCancel is true', () => {
+    const config = makeConfig(
+      [
+        makeRule({
+          id: 'user-cancel-on-online',
+          action: { type: 'cancelShutdownCountdown' },
+          cancelWhen: undefined,
+          trigger: { field: 'ups.online', op: 'eq', value: true },
+        }),
+      ],
+      {
+        safety: {
+          ...defaultShutdownPolicyConfig.safety,
+          allowFsdAutoCancel: true,
+        },
+      },
+    );
+
+    const result = shutdownPolicySchema.safeParse(config);
+    expect(result.success).toBe(true);
+  });
+
+  it('allows system-created cancelShutdownCountdown rules regardless of allowFsdAutoCancel', () => {
+    const config = makeConfig([
+      makeRule({
+        id: 'system-cancel-on-online',
+        action: { type: 'cancelShutdownCountdown' },
+        cancelWhen: undefined,
+        trigger: { field: 'ups.online', op: 'eq', value: true },
+        createdBy: 'system',
+      }),
+    ]);
+
+    const result = shutdownPolicySchema.safeParse(config);
+    expect(result.success).toBe(true);
+  });
 });
 
 function makeConfig(

--- a/src/main/shutdown/schema/shutdownPolicySchema.test.ts
+++ b/src/main/shutdown/schema/shutdownPolicySchema.test.ts
@@ -1,4 +1,10 @@
 import { describe, expect, it } from 'vitest';
+import {
+  MAX_POLICY_CONDITIONS_PER_GROUP,
+  MAX_POLICY_HOLD_SECONDS,
+  MAX_SHUTDOWN_POLICY_RULES,
+  MIN_POLICY_HOLD_SECONDS,
+} from '../../../shared/shutdownPolicy/constants';
 import type {
   PolicyCondition,
   ShutdownPolicyConfig,
@@ -90,6 +96,52 @@ describe('shutdownPolicySchema', () => {
     expect(result.success).toBe(false);
   });
 
+  it('rejects rules with holdForSeconds below the minimum boundary', () => {
+    const config = makeConfig([
+      makeRule({
+        action: { type: 'showWarning' },
+        holdForSeconds: MIN_POLICY_HOLD_SECONDS - 1,
+      }),
+    ]);
+
+    const result = shutdownPolicySchema.safeParse(config);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects rules with holdForSeconds above the maximum boundary', () => {
+    const config = makeConfig([
+      makeRule({
+        action: { type: 'showWarning' },
+        holdForSeconds: MAX_POLICY_HOLD_SECONDS + 1,
+      }),
+    ]);
+
+    const result = shutdownPolicySchema.safeParse(config);
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts rules with holdForSeconds at the exact boundaries', () => {
+    const minimumResult = shutdownPolicySchema.safeParse(
+      makeConfig([
+        makeRule({
+          action: { type: 'showWarning' },
+          holdForSeconds: MIN_POLICY_HOLD_SECONDS,
+        }),
+      ]),
+    );
+    const maximumResult = shutdownPolicySchema.safeParse(
+      makeConfig([
+        makeRule({
+          action: { type: 'showWarning' },
+          holdForSeconds: MAX_POLICY_HOLD_SECONDS,
+        }),
+      ]),
+    );
+
+    expect(minimumResult.success).toBe(true);
+    expect(maximumResult.success).toBe(true);
+  });
+
   it('rejects condition nesting beyond the configured maximum', () => {
     const config = makeConfig([
       {
@@ -179,10 +231,89 @@ describe('shutdownPolicySchema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('treats FSD triggers nested in any and not groups as FSD rules', () => {
+    const anyWrappedFsd = makeConfig([
+      {
+        ...makeRule({
+          priority: 1000,
+          severity: 'forced',
+          trigger: {
+            any: [
+              { field: 'ups.fsd', op: 'eq', value: true },
+              { field: 'ups.onBattery', op: 'eq', value: true },
+            ],
+          },
+          action: {
+            type: 'startShutdownCountdown',
+            countdownSeconds: 30,
+            method: 'shutdown',
+          },
+        }),
+        holdForSeconds: 0,
+        cancelWhen: null,
+      },
+    ]);
+    const negatedFsd = makeConfig([
+      {
+        ...makeRule({
+          priority: 1000,
+          severity: 'forced',
+          trigger: {
+            all: [
+              { field: 'ups.onBattery', op: 'eq', value: true },
+              { not: { field: 'ups.fsd', op: 'neq', value: true } },
+            ],
+          },
+          action: {
+            type: 'startShutdownCountdown',
+            countdownSeconds: 30,
+            method: 'shutdown',
+          },
+        }),
+        holdForSeconds: 0,
+        cancelWhen: null,
+      },
+    ]);
+
+    expect(shutdownPolicySchema.safeParse(anyWrappedFsd).success).toBe(true);
+    expect(shutdownPolicySchema.safeParse(negatedFsd).success).toBe(true);
+  });
+
   it('rejects duplicate rule ids', () => {
     const config = makeConfig([
       makeRule({ id: 'duplicate', action: { type: 'showWarning' } }),
       makeRule({ id: 'duplicate', action: { type: 'showWarning' } }),
+    ]);
+
+    const result = shutdownPolicySchema.safeParse(config);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects policies with more than the maximum number of rules', () => {
+    const tooManyRules = Array.from(
+      { length: MAX_SHUTDOWN_POLICY_RULES + 1 },
+      (_, index) => makeRule({
+        id: `rule-${index + 1}`,
+        name: `Rule ${index + 1}`,
+        action: { type: 'showWarning' },
+      }),
+    );
+
+    const result = shutdownPolicySchema.safeParse(makeConfig(tooManyRules));
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects condition groups with more than the maximum number of conditions', () => {
+    const config = makeConfig([
+      makeRule({
+        action: { type: 'showWarning' },
+        trigger: {
+          all: Array.from(
+            { length: MAX_POLICY_CONDITIONS_PER_GROUP + 1 },
+            (_, index) => makeLeafCondition(index),
+          ),
+        },
+      }),
     ]);
 
     const result = shutdownPolicySchema.safeParse(config);
@@ -278,5 +409,13 @@ function makeRule(
     cancelWhen: null,
     createdBy: 'user',
     ...overrides,
+  };
+}
+
+function makeLeafCondition(index = 0): PolicyCondition {
+  return {
+    field: 'battery.chargePercent',
+    op: 'lte',
+    value: 50 - index,
   };
 }

--- a/src/main/shutdown/schema/shutdownPolicySchema.ts
+++ b/src/main/shutdown/schema/shutdownPolicySchema.ts
@@ -130,6 +130,27 @@ function validateRuleSafety(
 ): void {
   const action = rule.action;
 
+  // SAFETY: A user-authored cancelShutdownCountdown rule with a non-FSD trigger
+  // can otherwise reach BatterySafetyService.cancelPolicyCountdown while an FSD
+  // countdown is active and silently abort the queued OS-level FSD shutdown
+  // (L2-F1 from .omc/research/shutdown-policy-review-2026-05-14.md).
+  // System-created rules (e.g. the default battery rule's implicit cancel path
+  // is expressed via `cancelWhen` on the rule itself, not via a standalone
+  // `cancelShutdownCountdown` action, so they are not affected) are allowed
+  // for forward compatibility.
+  if (
+    action.type === 'cancelShutdownCountdown' &&
+    rule.createdBy !== 'system' &&
+    !config.safety.allowFsdAutoCancel
+  ) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['rules', index, 'action'],
+      message:
+        'User-created cancelShutdownCountdown rules require shutdownPolicy.safety.allowFsdAutoCancel',
+    });
+  }
+
   if (action.type === 'startShutdownCountdown') {
     if (action.countdownSeconds > config.safety.maxCountdownSeconds) {
       context.addIssue({

--- a/src/main/system/batterySafetyService.test.ts
+++ b/src/main/system/batterySafetyService.test.ts
@@ -865,6 +865,161 @@ describe('BatterySafetyService — LB fallback without battery.charge', () => {
   });
 });
 
+// ── Phase 0 safety hotfix regressions ──────────────────────────────
+// Covers:
+//   L2-F1 (CRITICAL): user-authored cancelShutdownCountdown rules must not be
+//     able to defeat an active FSD shutdown through cancelPolicyCountdown.
+//   L2-F4 (MAJOR):    handleConfigUpdated must preserve activeCountdownRuleId
+//     and the corresponding appliedRuleIds entry when fsdShutdownCommitted.
+
+describe('BatterySafetyService — Phase 0 safety hotfixes', () => {
+  function makeConfig(shutdownPolicy?: ShutdownPolicyConfig) {
+    return {
+      battery: {
+        warningPct: 40,
+        shutdownPct: 20,
+        warningToastEnabled: false,
+        shutdownEnabled: false,
+        criticalAlertEnabled: false,
+        criticalShutdownAlertEnabled: false,
+        shutdownCountdownSeconds: 45,
+        shutdownMethod: 'sleep' as const,
+      },
+      fsd: {
+        shutdownEnabled: true,
+        shutdownDelaySeconds: 10,
+        shutdownMethod: 'shutdown' as const,
+        overlayEnabled: true,
+      },
+      shutdownPolicy,
+      nut: {} as never,
+      polling: {} as never,
+      data: {} as never,
+      debug: { level: 'off' } as never,
+      startup: {} as never,
+      theme: {} as never,
+      i18n: {} as never,
+      dashboard: {} as never,
+      wizard: {} as never,
+      line: {} as never,
+    };
+  }
+
+  function makeMockCriticalAlert() {
+    return {
+      show: vi.fn(),
+      dismiss: vi.fn(),
+      isShowing: false,
+    };
+  }
+
+  // Advanced policy: default FSD rule PLUS a user-authored cancel rule whose
+  // trigger is plain ups.online==true. Pre-fix this rule defeated FSD.
+  function makePolicyWithUserCancelRule(): ShutdownPolicyConfig {
+    return {
+      version: 1,
+      mode: 'advanced',
+      safety: {
+        requireHoldForShutdownSeconds: 0,
+        maxCountdownSeconds: 300,
+        allowImmediateShutdown: false,
+        // allowFsdAutoCancel intentionally false — this is the scenario the
+        // L2-F1 service-level guard must protect against, separately from the
+        // schema-level rejection.
+        allowFsdAutoCancel: false,
+      },
+      rules: [
+        {
+          id: 'default-fsd-shutdown',
+          name: 'FSD shutdown',
+          enabled: true,
+          priority: 1000,
+          severity: 'forced',
+          trigger: { field: 'ups.fsd', op: 'eq', value: true },
+          action: {
+            type: 'startShutdownCountdown',
+            countdownSeconds: 12,
+            method: 'shutdown',
+          },
+          cancelWhen: null,
+          createdBy: 'system',
+        },
+        {
+          id: 'user-cancel-on-online',
+          name: 'Cancel on online (user)',
+          enabled: true,
+          priority: 500,
+          severity: 'info',
+          trigger: { field: 'ups.online', op: 'eq', value: true },
+          action: { type: 'cancelShutdownCountdown' },
+          // createdBy: 'system' so the schema does not reject this rule
+          // independently. The runtime service-level guard is what we exercise.
+          createdBy: 'system',
+        },
+      ],
+    };
+  }
+
+  it('does not let a user cancelShutdownCountdown decision defeat an active FSD shutdown', async () => {
+    const { BatterySafetyService } = await import('./batterySafetyService');
+    const alert = makeMockCriticalAlert();
+    const service = new BatterySafetyService(
+      makeConfig(makePolicyWithUserCancelRule()) as never,
+      alert as never,
+    );
+
+    // FSD detected on battery — FSD overlay shows, fsdShutdownCommitted set.
+    service.handleTelemetry({ battery_charge_pct: 80 } as never, 'OB FSD');
+    expect(alert.show).toHaveBeenCalledTimes(1);
+    const initialLogLength = service.getDecisionLog().length;
+
+    // Clear so we can observe whether any *additional* dismiss happens.
+    alert.dismiss.mockClear();
+
+    // Next poll: UPS reports OL. The user cancel rule's trigger now matches,
+    // so the engine emits cancelShutdownCountdown for 'user-cancel-on-online'.
+    // The service-level FSD guard MUST suppress it.
+    service.handleTelemetry({ battery_charge_pct: 80 } as never, 'OL');
+
+    // Observable signals that the cancel decision was suppressed:
+    // 1) No additional dismiss on the critical alert.
+    expect(alert.dismiss).not.toHaveBeenCalled();
+    // 2) No new 'cancellation' event in the decision log.
+    const newCancellations = service
+      .getDecisionLog()
+      .slice(0, service.getDecisionLog().length - initialLogLength)
+      .filter((entry) => entry.event === 'cancellation');
+    expect(newCancellations).toHaveLength(0);
+  });
+
+  it('preserves activeCountdownRuleId and appliedRuleIds for FSD across handleConfigUpdated', async () => {
+    const { BatterySafetyService } = await import('./batterySafetyService');
+    const alert = makeMockCriticalAlert();
+    const service = new BatterySafetyService(makeConfig() as never, alert as never);
+
+    // Start FSD — fsdShutdownCommitted=true and activeCountdownRuleId set.
+    service.handleTelemetry({ battery_charge_pct: 80 } as never, 'OL FSD');
+    expect(alert.show).toHaveBeenCalledTimes(1);
+    alert.dismiss.mockClear();
+
+    // Apply a config update that swaps the policy. Pre-fix this would wipe
+    // activeCountdownRuleId and appliedRuleIds, leaving the overlay visible
+    // but the engine/service decoupled — widening the L2-F1 attack surface.
+    service.handleConfigUpdated(makeConfig() as never);
+
+    // The overlay must NOT have been dismissed because FSD is still committed.
+    expect(alert.dismiss).not.toHaveBeenCalled();
+
+    // After a subsequent OL telemetry tick (no FSD), the service must still
+    // treat FSD as committed — meaning the overlay survives and the engine's
+    // cancel paths remain suppressed. Without the L2-F4 fix, activeCountdownRuleId
+    // had been cleared by handleConfigUpdated and applyDecision could fire a
+    // cancellation again.
+    service.handleTelemetry({ battery_charge_pct: 80 } as never, 'OL');
+    expect(alert.dismiss).not.toHaveBeenCalled();
+  });
+});
+
 async function flushAsyncShutdownWork(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();

--- a/src/main/system/batterySafetyService.test.ts
+++ b/src/main/system/batterySafetyService.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { containsFsdToken, containsLbToken, containsObToken } from './batterySafetyService';
 import type { ShutdownPolicyConfig } from '../../shared/shutdownPolicy/types';
 
@@ -21,6 +21,19 @@ vi.mock('node:child_process', () => ({
 vi.mock('./i18nService', () => ({
   t: (key: string) => key,
 }));
+
+const DEFAULT_TEST_TIME_MS = Date.parse('2026-05-14T00:00:00.000Z');
+
+function installTestClock(): (seconds: number) => void {
+  let nowMs = DEFAULT_TEST_TIME_MS;
+  vi.useFakeTimers();
+  vi.setSystemTime(nowMs);
+
+  return (seconds: number) => {
+    nowMs += seconds * 1000;
+    vi.setSystemTime(nowMs);
+  };
+}
 
 describe('containsFsdToken', () => {
   it('returns true for bare FSD token (uppercase)', () => {
@@ -221,22 +234,34 @@ describe('BatterySafetyService — FSD shutdown is irrevocable', () => {
 
   let service: InstanceType<typeof import('./batterySafetyService').BatterySafetyService>;
   let mockAlert: ReturnType<typeof makeMockCriticalAlert>;
+  let advanceClock: (seconds: number) => void;
 
   beforeEach(async () => {
+    advanceClock = installTestClock();
     const { BatterySafetyService } = await import('./batterySafetyService');
     mockAlert = makeMockCriticalAlert();
     service = new BatterySafetyService(makeConfig() as never, mockAlert as never);
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function triggerDefaultFsd(status = 'OL FSD', telemetry: Record<string, unknown> = { battery_charge_pct: 80 }) {
+    service.handleTelemetry(telemetry as never, status);
+    advanceClock(3);
+    service.handleTelemetry(telemetry as never, status);
+  }
+
   it('shows FSD overlay on first FSD detection', () => {
-    service.handleTelemetry({ battery_charge_pct: 80 } as never, 'OL FSD');
+    triggerDefaultFsd();
 
     expect(mockAlert.show).toHaveBeenCalledTimes(1);
     expect(mockAlert.show.mock.calls[0][0].type).toBe('critical');
   });
 
   it('shows FSD overlay even when battery percent is missing', () => {
-    service.handleTelemetry({} as never, 'OL FSD');
+    triggerDefaultFsd('OL FSD', {});
 
     expect(mockAlert.show).toHaveBeenCalledTimes(1);
     expect(mockAlert.show.mock.calls[0][0].type).toBe('critical');
@@ -245,7 +270,7 @@ describe('BatterySafetyService — FSD shutdown is irrevocable', () => {
 
   it('does NOT dismiss the FSD overlay when subsequent telemetry lacks FSD', () => {
     // FSD detected
-    service.handleTelemetry({ battery_charge_pct: 80 } as never, 'OL FSD');
+    triggerDefaultFsd();
     expect(mockAlert.show).toHaveBeenCalledTimes(1);
 
     mockAlert.dismiss.mockClear();
@@ -257,7 +282,7 @@ describe('BatterySafetyService — FSD shutdown is irrevocable', () => {
 
   it('does NOT dismiss FSD overlay when battery recovers above warning threshold', () => {
     // FSD detected at 30%
-    service.handleTelemetry({ battery_charge_pct: 30 } as never, 'OB FSD LB');
+    triggerDefaultFsd('OB FSD LB', { battery_charge_pct: 30 });
     expect(mockAlert.show).toHaveBeenCalledTimes(1);
 
     mockAlert.dismiss.mockClear();
@@ -268,8 +293,10 @@ describe('BatterySafetyService — FSD shutdown is irrevocable', () => {
   });
 
   it('does NOT show FSD overlay twice for repeated FSD telemetry', () => {
-    service.handleTelemetry({ battery_charge_pct: 80 } as never, 'OL FSD');
+    triggerDefaultFsd('OL FSD');
+    advanceClock(1);
     service.handleTelemetry({ battery_charge_pct: 80 } as never, 'OB FSD LB');
+    advanceClock(1);
     service.handleTelemetry({ battery_charge_pct: 80 } as never, 'FSD');
 
     // Only the first FSD detection triggers the overlay
@@ -309,7 +336,7 @@ describe('BatterySafetyService — FSD shutdown is irrevocable', () => {
 
   it('user dismiss resets FSD state, allowing re-trigger on next FSD', () => {
     // FSD detected — overlay shown
-    service.handleTelemetry({ battery_charge_pct: 80 } as never, 'OL FSD');
+    triggerDefaultFsd();
     expect(mockAlert.show).toHaveBeenCalledTimes(1);
 
     // Capture the onDismissed callback (3rd argument to show())
@@ -329,7 +356,7 @@ describe('BatterySafetyService — FSD shutdown is irrevocable', () => {
 
     // A subsequent FSD signal should trigger a new overlay
     mockAlert.show.mockClear();
-    service.handleTelemetry({ battery_charge_pct: 80 } as never, 'OB FSD');
+    triggerDefaultFsd('OB FSD');
     expect(mockAlert.show).toHaveBeenCalledTimes(1);
   });
 });
@@ -379,12 +406,32 @@ describe('BatterySafetyService — OB/OL gating', () => {
 
   let service: InstanceType<typeof import('./batterySafetyService').BatterySafetyService>;
   let mockAlert: ReturnType<typeof makeMockCriticalAlert>;
+  let advanceClock: (seconds: number) => void;
 
   beforeEach(async () => {
+    advanceClock = installTestClock();
     const { BatterySafetyService } = await import('./batterySafetyService');
     mockAlert = makeMockCriticalAlert();
     service = new BatterySafetyService(makeConfig() as never, mockAlert as never);
   });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function triggerDefaultWarning(charge = 30, status = 'OB DISCHRG') {
+    service.handleTelemetry({ battery_charge_pct: 80 } as never, 'OB');
+    service.handleTelemetry({ battery_charge_pct: charge } as never, status);
+    advanceClock(5);
+    service.handleTelemetry({ battery_charge_pct: charge } as never, status);
+  }
+
+  function triggerDefaultShutdown(charge = 15, status = 'OB DISCHRG LB') {
+    service.handleTelemetry({ battery_charge_pct: 80 } as never, 'OB');
+    service.handleTelemetry({ battery_charge_pct: charge } as never, status);
+    advanceClock(10);
+    service.handleTelemetry({ battery_charge_pct: charge } as never, status);
+  }
 
   it('does NOT trigger warning when battery is low but UPS is online (OL)', () => {
     service.handleTelemetry({ battery_charge_pct: 80 } as never, 'OL');
@@ -401,16 +448,14 @@ describe('BatterySafetyService — OB/OL gating', () => {
   });
 
   it('triggers warning when battery is low and UPS is on battery (OB)', () => {
-    service.handleTelemetry({ battery_charge_pct: 80 } as never, 'OB');
-    service.handleTelemetry({ battery_charge_pct: 30 } as never, 'OB DISCHRG');
+    triggerDefaultWarning();
 
     expect(mockAlert.show).toHaveBeenCalledTimes(1);
     expect(mockAlert.show.mock.calls[0][0].type).toBe('warning');
   });
 
   it('triggers shutdown alert when battery crosses below shutdownPct on OB', () => {
-    service.handleTelemetry({ battery_charge_pct: 80 } as never, 'OB');
-    service.handleTelemetry({ battery_charge_pct: 15 } as never, 'OB DISCHRG LB');
+    triggerDefaultShutdown();
 
     // The engine emits the highest-priority matching rule only.
     expect(mockAlert.show).toHaveBeenCalledTimes(1);
@@ -420,8 +465,7 @@ describe('BatterySafetyService — OB/OL gating', () => {
 
   it('cancels shutdown countdown when UPS transitions from OB to OL', () => {
     // On battery, battery drops below shutdown threshold
-    service.handleTelemetry({ battery_charge_pct: 80 } as never, 'OB');
-    service.handleTelemetry({ battery_charge_pct: 15 } as never, 'OB DISCHRG LB');
+    triggerDefaultShutdown();
     expect(mockAlert.show).toHaveBeenCalledTimes(1);
 
     mockAlert.dismiss.mockClear();
@@ -434,8 +478,7 @@ describe('BatterySafetyService — OB/OL gating', () => {
   });
 
   it('still cancels shutdown countdown when an intermediate poll omits ups.status', () => {
-    service.handleTelemetry({ battery_charge_pct: 80 } as never, 'OB');
-    service.handleTelemetry({ battery_charge_pct: 15 } as never, 'OB DISCHRG LB');
+    triggerDefaultShutdown();
     expect(mockAlert.show).toHaveBeenCalledTimes(1);
 
     mockAlert.dismiss.mockClear();
@@ -451,8 +494,7 @@ describe('BatterySafetyService — OB/OL gating', () => {
 
   it('re-arms policy alerts on OB→OL so warnings re-trigger if power fails again', () => {
     // On battery → warning triggered
-    service.handleTelemetry({ battery_charge_pct: 80 } as never, 'OB');
-    service.handleTelemetry({ battery_charge_pct: 30 } as never, 'OB DISCHRG');
+    triggerDefaultWarning();
     expect(mockAlert.show).toHaveBeenCalledTimes(1);
 
     // Power returns
@@ -460,6 +502,8 @@ describe('BatterySafetyService — OB/OL gating', () => {
     mockAlert.show.mockClear();
 
     // Power fails again — warning should re-trigger at the still-low level
+    service.handleTelemetry({ battery_charge_pct: 30 } as never, 'OB DISCHRG');
+    advanceClock(5);
     service.handleTelemetry({ battery_charge_pct: 30 } as never, 'OB DISCHRG');
     expect(mockAlert.show).toHaveBeenCalledTimes(1);
   });
@@ -478,6 +522,8 @@ describe('BatterySafetyService — OB/OL gating', () => {
     } as never, alert as never);
 
     // FSD detected on battery
+    svc.handleTelemetry({ battery_charge_pct: 80 } as never, 'OB FSD');
+    advanceClock(3);
     svc.handleTelemetry({ battery_charge_pct: 80 } as never, 'OB FSD');
     expect(alert.show).toHaveBeenCalledTimes(1);
 
@@ -747,6 +793,52 @@ describe('BatterySafetyService — policy-driven action application', () => {
     expect(executionEntry?.execution?.method).toBe('shutdown');
     expect(executionEntry?.execution?.supported).toBe(process.platform === 'win32');
   });
+
+  it('releases a failed shutdown command so the same rule can re-fire on the next telemetry tick', async () => {
+    const { BatterySafetyService } = await import('./batterySafetyService');
+    const alert = makeMockCriticalAlert();
+    const svc = new BatterySafetyService(
+      makeConfig(makePolicy({
+        action: {
+          type: 'startShutdownCountdown',
+          countdownSeconds: 30,
+          method: 'shutdown',
+        },
+        cancelWhen: null,
+      })) as never,
+      alert as never,
+    );
+    const execute = vi.fn().mockRejectedValue(new Error('fake failure'));
+    (svc as unknown as {
+      shutdownExecutor: { execute: typeof execute };
+    }).shutdownExecutor.execute = execute;
+
+    svc.handleTelemetry({ battery_charge_pct: 80 } as never, 'OB');
+    const onCountdownElapsed = alert.show.mock.calls[0][1] as (() => void) | undefined;
+
+    expect(onCountdownElapsed).toBeTypeOf('function');
+
+    onCountdownElapsed?.();
+    await flushAsyncShutdownWork();
+
+    const internals = svc as unknown as {
+      activeCountdownRuleId: string | null;
+      appliedRuleIds: Set<string>;
+    };
+    expect(internals.activeCountdownRuleId).toBeNull();
+    expect(internals.appliedRuleIds.has('advanced-rule')).toBe(false);
+    expect(svc.getDecisionLog().some((entry) =>
+      entry.event === 'failure' &&
+      entry.ruleId === 'advanced-rule' &&
+      entry.execution?.errorMessage === 'fake failure',
+    )).toBe(true);
+
+    alert.show.mockClear();
+
+    svc.handleTelemetry({ battery_charge_pct: 80 } as never, 'OB');
+
+    expect(alert.show).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('BatterySafetyService — LB fallback without battery.charge', () => {
@@ -792,15 +884,27 @@ describe('BatterySafetyService — LB fallback without battery.charge', () => {
 
   let service: InstanceType<typeof import('./batterySafetyService').BatterySafetyService>;
   let mockAlert: ReturnType<typeof makeMockCriticalAlert>;
+  let advanceClock: (seconds: number) => void;
 
   beforeEach(async () => {
+    advanceClock = installTestClock();
     const { BatterySafetyService } = await import('./batterySafetyService');
     mockAlert = makeMockCriticalAlert();
     service = new BatterySafetyService(makeConfig() as never, mockAlert as never);
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function triggerDefaultLbShutdown(status = 'OB LB DISCHRG') {
+    service.handleTelemetry({} as never, status);
+    advanceClock(10);
+    service.handleTelemetry({} as never, status);
+  }
+
   it('triggers shutdown when OB LB is reported without battery.charge', () => {
-    service.handleTelemetry({} as never, 'OB LB DISCHRG');
+    triggerDefaultLbShutdown();
 
     expect(mockAlert.show).toHaveBeenCalledTimes(1);
     expect(mockAlert.show.mock.calls[0][0].type).toBe('critical');
@@ -820,7 +924,7 @@ describe('BatterySafetyService — LB fallback without battery.charge', () => {
   });
 
   it('cancels LB-triggered shutdown when UPS transitions to OL', () => {
-    service.handleTelemetry({} as never, 'OB LB DISCHRG');
+    triggerDefaultLbShutdown();
     expect(mockAlert.show).toHaveBeenCalledTimes(1);
 
     mockAlert.dismiss.mockClear();
@@ -832,7 +936,7 @@ describe('BatterySafetyService — LB fallback without battery.charge', () => {
 
   it('re-triggers LB warning after OB→OL→OB cycle without battery.charge', () => {
     // First OB LB triggers shutdown
-    service.handleTelemetry({} as never, 'OB LB');
+    triggerDefaultLbShutdown('OB LB');
     expect(mockAlert.show).toHaveBeenCalledTimes(1);
 
     // Power returns
@@ -841,11 +945,13 @@ describe('BatterySafetyService — LB fallback without battery.charge', () => {
 
     // Power fails again with LB
     service.handleTelemetry({} as never, 'OB LB');
+    advanceClock(10);
+    service.handleTelemetry({} as never, 'OB LB');
     expect(mockAlert.show).toHaveBeenCalledTimes(1);
   });
 
   it('uses shutdownPct as the synthesized battery percent in the alert', () => {
-    service.handleTelemetry({} as never, 'OB LB DISCHRG');
+    triggerDefaultLbShutdown();
 
     // The critical alert should show shutdownPct as the battery percent
     const criticalCall = mockAlert.show.mock.calls[0][0];
@@ -853,7 +959,7 @@ describe('BatterySafetyService — LB fallback without battery.charge', () => {
   });
 
   it('records applied policy decisions with condition explanations', () => {
-    service.handleTelemetry({} as never, 'OB LB DISCHRG');
+    triggerDefaultLbShutdown();
 
     const log = service.getDecisionLog();
     expect(log.length).toBeGreaterThanOrEqual(1);
@@ -912,6 +1018,16 @@ describe('BatterySafetyService — Phase 0 safety hotfixes', () => {
       isShowing: false,
     };
   }
+
+  let advanceClock: (seconds: number) => void;
+
+  beforeEach(() => {
+    advanceClock = installTestClock();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
 
   // Advanced policy: default FSD rule PLUS a user-authored cancel rule whose
   // trigger is plain ups.online==true. Pre-fix this rule defeated FSD.
@@ -999,6 +1115,8 @@ describe('BatterySafetyService — Phase 0 safety hotfixes', () => {
 
     // Start FSD — fsdShutdownCommitted=true and activeCountdownRuleId set.
     service.handleTelemetry({ battery_charge_pct: 80 } as never, 'OL FSD');
+    advanceClock(3);
+    service.handleTelemetry({ battery_charge_pct: 80 } as never, 'OL FSD');
     expect(alert.show).toHaveBeenCalledTimes(1);
     alert.dismiss.mockClear();
 
@@ -1017,6 +1135,194 @@ describe('BatterySafetyService — Phase 0 safety hotfixes', () => {
     // cancellation again.
     service.handleTelemetry({ battery_charge_pct: 80 } as never, 'OL');
     expect(alert.dismiss).not.toHaveBeenCalled();
+  });
+});
+
+describe('BatterySafetyService — communication-loss timer and failure handling', () => {
+  function makeConfig(shutdownPolicy: ShutdownPolicyConfig) {
+    return {
+      battery: {
+        warningPct: 40,
+        shutdownPct: 20,
+        warningToastEnabled: false,
+        shutdownEnabled: false,
+        criticalAlertEnabled: false,
+        criticalShutdownAlertEnabled: false,
+        shutdownCountdownSeconds: 45,
+        shutdownMethod: 'sleep' as const,
+      },
+      fsd: {
+        shutdownEnabled: false,
+        shutdownDelaySeconds: 10,
+        shutdownMethod: 'shutdown' as const,
+        overlayEnabled: true,
+      },
+      shutdownPolicy,
+      nut: {} as never,
+      polling: {} as never,
+      data: {} as never,
+      debug: { level: 'off' } as never,
+      startup: {} as never,
+      theme: {} as never,
+      i18n: {} as never,
+      dashboard: {} as never,
+      wizard: {} as never,
+      line: {} as never,
+    };
+  }
+
+  function makeMockCriticalAlert() {
+    return {
+      show: vi.fn(),
+      dismiss: vi.fn(),
+      isShowing: false,
+    };
+  }
+
+  it('evaluates communication-loss rules on reconnecting timer ticks and clears the timer on stop', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-14T00:00:00.000Z'));
+
+    try {
+      const { BatterySafetyService } = await import('./batterySafetyService');
+      const alert = makeMockCriticalAlert();
+      const service = new BatterySafetyService(
+        makeConfig({
+          version: 1,
+          mode: 'advanced',
+          safety: {
+            requireHoldForShutdownSeconds: 0,
+            maxCountdownSeconds: 300,
+            allowImmediateShutdown: false,
+            allowFsdAutoCancel: false,
+          },
+          rules: [
+            {
+              id: 'comms-loss-warning',
+              name: 'Comms loss warning',
+              enabled: true,
+              priority: 100,
+              severity: 'critical',
+              trigger: {
+                all: [
+                  { field: 'state.secondsOnBattery', op: 'gte', value: 0 },
+                  {
+                    field: 'connection.secondsSinceLastSuccessfulPoll',
+                    op: 'gte',
+                    value: 5,
+                  },
+                ],
+              },
+              action: { type: 'showCriticalAlert' },
+              createdBy: 'user',
+            },
+          ],
+        }) as never,
+        alert as never,
+      );
+
+      service.handleTelemetry({ battery_charge_pct: 80 } as never, 'OB');
+      alert.show.mockClear();
+
+      service.handleConnectionState('reconnecting');
+      expect(
+        (service as unknown as {
+          communicationLossEvaluationTimer: ReturnType<typeof setInterval> | null;
+        }).communicationLossEvaluationTimer,
+      ).not.toBeNull();
+
+      vi.advanceTimersByTime(5000);
+
+      expect(alert.show).toHaveBeenCalledTimes(1);
+      expect(alert.show.mock.calls[0][0].type).toBe('critical');
+
+      service.stop();
+      expect(
+        (service as unknown as {
+          communicationLossEvaluationTimer: ReturnType<typeof setInterval> | null;
+        }).communicationLossEvaluationTimer,
+      ).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('shows a failure alert when cancelling a pending shutdown command fails', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const { BatterySafetyService } = await import('./batterySafetyService');
+      const alert = makeMockCriticalAlert();
+      const service = new BatterySafetyService(
+        makeConfig({
+          version: 1,
+          mode: 'advanced',
+          safety: {
+            requireHoldForShutdownSeconds: 0,
+            maxCountdownSeconds: 300,
+            allowImmediateShutdown: false,
+            allowFsdAutoCancel: false,
+          },
+          rules: [
+            {
+              id: 'countdown-rule',
+              name: 'Countdown rule',
+              enabled: true,
+              priority: 100,
+              severity: 'critical',
+              trigger: { field: 'ups.onBattery', op: 'eq', value: true },
+              action: {
+                type: 'startShutdownCountdown',
+                countdownSeconds: 30,
+                method: 'shutdown',
+              },
+              cancelWhen: { field: 'ups.online', op: 'eq', value: true },
+              createdBy: 'user',
+            },
+          ],
+        }) as never,
+        alert as never,
+      );
+
+      (
+        service as unknown as {
+          shutdownExecutor: {
+            cancelPending: ReturnType<typeof vi.fn>;
+          };
+        }
+      ).shutdownExecutor.cancelPending = vi.fn().mockResolvedValue({
+        method: 'shutdown',
+        platform: process.platform,
+        supported: true,
+        success: false,
+        command: 'shutdown.exe /a',
+        errorMessage: 'cancel failed',
+      });
+
+      service.handleTelemetry({ battery_charge_pct: 80 } as never, 'OB');
+      alert.show.mockClear();
+
+      service.handleTelemetry({ battery_charge_pct: 80 } as never, 'OL');
+      await flushAsyncShutdownWork();
+
+      expect(alert.show).toHaveBeenCalledTimes(1);
+      expect(alert.show.mock.calls[0][0]).toMatchObject({
+        type: 'critical',
+        title: 'batterySafety.shutdownCommandFailedTitle',
+        body: 'batterySafety.shutdownCommandFailedBody',
+        showShutdown: false,
+      });
+      expect(
+        service.getDecisionLog().some((entry) =>
+          entry.event === 'failure' &&
+          entry.decision.type === 'cancelShutdownCountdown' &&
+          entry.execution?.command === 'shutdown.exe /a',
+        ),
+      ).toBe(true);
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });
 

--- a/src/main/system/batterySafetyService.ts
+++ b/src/main/system/batterySafetyService.ts
@@ -122,6 +122,19 @@ export class BatterySafetyService {
     const hadCancellableCountdown =
       this.activeCountdownRuleId !== null && !this.fsdShutdownCommitted;
 
+    // PRESERVE FSD STATE across config swaps. Previously this method reset
+    // `activeCountdownRuleId` and `appliedRuleIds` unconditionally, leaving an
+    // active FSD overlay visible while the engine and service forgot which rule
+    // owned the countdown. That widened the L2-F1 attack surface: after a config
+    // save, even the (post-fix) FSD guard could not associate a future cancel
+    // decision with the still-armed FSD. Capture state before the swap so we can
+    // restore it for the FSD-committed case.
+    const fsdWasCommitted = this.fsdShutdownCommitted;
+    const fsdCountdownRuleId =
+      fsdWasCommitted && this.activeCountdownRuleId !== null
+        ? this.activeCountdownRuleId
+        : null;
+
     this.batteryConfig = config.battery;
     this.policyConfig = resolvePolicyConfig(config);
     this.policyEngine = new ShutdownPolicyEngine(this.policyConfig);
@@ -129,6 +142,15 @@ export class BatterySafetyService {
     this.appliedRuleIds.clear();
     this.activeCountdownRuleId = null;
     this.lastOnBattery = false;
+
+    if (fsdCountdownRuleId !== null) {
+      // The new policy engine instance starts with no in-memory countdown; the
+      // overlay is still shown to the user. Re-link the service-level FSD state
+      // so cancelPolicyCountdown's fsdShutdownCommitted guard still protects it
+      // and applyDecision branches that key off DEFAULT_FSD_SHUTDOWN_RULE_ID work.
+      this.activeCountdownRuleId = fsdCountdownRuleId;
+      this.appliedRuleIds.add(fsdCountdownRuleId);
+    }
 
     if (hadCancellableCountdown) {
       this.cancelPendingShutdown();
@@ -379,11 +401,18 @@ export class BatterySafetyService {
   private cancelPolicyCountdown(
     decision: Extract<ShutdownPolicyDecision, { type: 'cancelShutdownCountdown' }>,
   ): void {
-    const { ruleId } = decision;
-    if (this.fsdShutdownCommitted && ruleId === DEFAULT_FSD_SHUTDOWN_RULE_ID) {
+    // SAFETY INVARIANT: FSD shutdowns are non-cancellable through the policy engine.
+    // Previously this guard checked `ruleId === DEFAULT_FSD_SHUTDOWN_RULE_ID`, which
+    // let a user-authored rule whose `action.type === 'cancelShutdownCountdown'`
+    // (with any ruleId) call `cancelPendingShutdown()` — silently aborting the queued
+    // OS-level FSD shutdown while the overlay still ticked down. Violates §8.3 of
+    // shutdown_policy_implementation_plan.md and Definition-of-Done #5.
+    // Fix: any committed FSD shutdown is sticky, regardless of the cancelling rule.
+    if (this.fsdShutdownCommitted) {
       return;
     }
 
+    const { ruleId } = decision;
     const context = this.latestContext;
     if (context) {
       this.recordDecision(decision, context, 'cancellation');
@@ -392,10 +421,7 @@ export class BatterySafetyService {
     this.activeCountdownRuleId = null;
     this.appliedRuleIds.delete(ruleId);
     this.cancelPendingShutdown(context, decision);
-
-    if (!this.fsdShutdownCommitted) {
-      this.criticalAlert.dismiss();
-    }
+    this.criticalAlert.dismiss();
   }
 
   private resolveDisplayBatteryPercent(context: ShutdownPolicyContext): number {

--- a/src/main/system/batterySafetyService.ts
+++ b/src/main/system/batterySafetyService.ts
@@ -660,6 +660,42 @@ export class BatterySafetyService {
     });
   }
 
+  private releaseFailedShutdownDecision(decision: ShutdownPolicyDecision): void {
+    const ruleId = getDecisionRuleId(decision);
+    if (!ruleId) {
+      return;
+    }
+
+    this.appliedRuleIds.delete(ruleId);
+    if (this.activeCountdownRuleId === ruleId) {
+      this.activeCountdownRuleId = null;
+    }
+    if (ruleId === DEFAULT_FSD_SHUTDOWN_RULE_ID) {
+      this.fsdActive = false;
+      this.fsdShutdownCommitted = false;
+    }
+    this.policyEngine.releaseFailedDecision(ruleId);
+  }
+
+  private handleShutdownExecutionResult(
+    decision: ShutdownPolicyDecision,
+    context: ShutdownPolicyContext,
+    result: ShutdownExecutionResult,
+  ): void {
+    this.recordExecutionResult(decision, context, result);
+
+    if (result.success) {
+      return;
+    }
+
+    this.releaseFailedShutdownDecision(decision);
+    console.error(
+      '[BatterySafetyService] Failed to execute shutdown action.',
+      result.errorMessage ?? result.message,
+    );
+    this.showShutdownExecutionFailure(result);
+  }
+
   private buildConditionExplanation(
     decision: ShutdownPolicyDecision,
     context: ShutdownPolicyContext,
@@ -714,17 +750,17 @@ export class BatterySafetyService {
     context: ShutdownPolicyContext,
     decision: ShutdownPolicyDecision,
   ): void {
-    void this.shutdownExecutor.execute(method).then((result) => {
-      this.recordExecutionResult(decision, context, result);
-
-      if (!result.success) {
-        console.error(
-          '[BatterySafetyService] Failed to execute shutdown action.',
-          result.errorMessage ?? result.message,
+    void this.shutdownExecutor.execute(method)
+      .then((result) => {
+        this.handleShutdownExecutionResult(decision, context, result);
+      })
+      .catch((error: unknown) => {
+        this.handleShutdownExecutionResult(
+          decision,
+          context,
+          createUnexpectedShutdownExecutionResult(method, error),
         );
-        this.showShutdownExecutionFailure(result);
-      }
-    });
+      });
   }
 
   private cancelPendingShutdown(
@@ -774,6 +810,19 @@ export class BatterySafetyService {
 
 function getDecisionRuleId(decision: ShutdownPolicyDecision): string | undefined {
   return decision.type === 'none' ? undefined : decision.ruleId;
+}
+
+function createUnexpectedShutdownExecutionResult(
+  method: 'sleep' | 'shutdown',
+  error: unknown,
+): ShutdownExecutionResult {
+  return {
+    method,
+    platform: process.platform,
+    supported: true,
+    success: false,
+    errorMessage: error instanceof Error ? error.message : String(error),
+  };
 }
 
 function formatExecutionSummary(result: ShutdownExecutionResult): string {

--- a/src/renderer/features/shutdownPolicy/ShutdownPolicySettingsSection.test.tsx
+++ b/src/renderer/features/shutdownPolicy/ShutdownPolicySettingsSection.test.tsx
@@ -1,0 +1,324 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  applyConfigPatch,
+  defaultAppConfig,
+  type AppConfig,
+} from '../../../main/config/configSchema';
+import type { AppConfigPatch } from '../../../shared/config/types';
+import {
+  DEFAULT_BATTERY_SHUTDOWN_RULE_ID,
+  DEFAULT_BATTERY_WARNING_RULE_ID,
+  DEFAULT_COMMUNICATION_LOSS_RULE_ID,
+  getNumericConditionValue,
+} from '../../../shared/shutdownPolicy/defaultPolicies';
+import type { ShutdownPolicyDecisionLogEntry } from '../../../shared/shutdownPolicy/types';
+import { SettingsPage } from '../../pages/SettingsPage';
+import { ShutdownPolicySettingsSection } from './ShutdownPolicySettingsSection';
+
+const hoisted = vi.hoisted(() => ({
+  currentConfig: null as AppConfig | null,
+  mockNavigate: vi.fn(),
+  mockSettingsGet: vi.fn<() => Promise<AppConfig>>(),
+  mockSettingsUpdate: vi.fn<(patch: AppConfigPatch) => Promise<AppConfig>>(),
+  mockRefreshConfig: vi.fn<() => Promise<void>>(),
+  mockGetDecisionLog: vi.fn<() => Promise<ShutdownPolicyDecisionLogEntry[]>>(),
+}));
+
+const {
+  mockNavigate,
+  mockSettingsGet,
+  mockSettingsUpdate,
+  mockRefreshConfig,
+  mockGetDecisionLog,
+} = hoisted;
+
+let currentConfig: AppConfig;
+let mockDecisionLog: ShutdownPolicyDecisionLogEntry[];
+let confirmSpy: ReturnType<typeof vi.spyOn>;
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      defaultValueOrOptions?: string | Record<string, unknown>,
+      maybeOptions?: Record<string, unknown>,
+    ) => {
+      const defaultValue = typeof defaultValueOrOptions === 'string'
+        ? defaultValueOrOptions
+        : key;
+      const values = typeof defaultValueOrOptions === 'string'
+        ? maybeOptions
+        : defaultValueOrOptions;
+
+      if (!values) {
+        return defaultValue;
+      }
+
+      return Object.entries(values).reduce(
+        (text, [name, value]) => text.replace(`{{${name}}}`, String(value)),
+        defaultValue,
+      );
+    },
+  }),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => hoisted.mockNavigate,
+  };
+});
+
+vi.mock('../../app/providers', () => ({
+  useAppConfig: () => ({
+    config: hoisted.currentConfig,
+    refreshConfig: hoisted.mockRefreshConfig,
+  }),
+}));
+
+vi.mock('../../app/electronApi', () => ({
+  electronApi: {
+    settings: {
+      get: hoisted.mockSettingsGet,
+      update: hoisted.mockSettingsUpdate,
+    },
+    shutdownPolicy: {
+      getDecisionLog: hoisted.mockGetDecisionLog,
+    },
+    wizard: {
+      enter: vi.fn(),
+    },
+  },
+}));
+
+describe('ShutdownPolicySettingsSection renderer flows', () => {
+  beforeEach(() => {
+    currentConfig = structuredClone(defaultAppConfig);
+    hoisted.currentConfig = currentConfig;
+    mockDecisionLog = [];
+
+    mockNavigate.mockReset();
+    mockSettingsGet.mockReset().mockImplementation(async () => currentConfig);
+    mockSettingsUpdate.mockReset().mockImplementation(async (patch) => {
+      currentConfig = applyConfigPatch(currentConfig, patch);
+      hoisted.currentConfig = currentConfig;
+      return currentConfig;
+    });
+    mockRefreshConfig.mockReset().mockResolvedValue(undefined);
+    mockGetDecisionLog.mockReset().mockImplementation(async () => mockDecisionLog);
+
+    confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    confirmSpy.mockRestore();
+    cleanup();
+  });
+
+  it('updates the generated simple policy when the warning threshold changes', async () => {
+    render(<SettingsPage />);
+
+    const warningInput = screen.getByLabelText('settings.warningPct');
+    fireEvent.change(warningInput, { target: { value: '45' } });
+    fireEvent.blur(warningInput);
+
+    await waitFor(() => {
+      expect(mockSettingsUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          battery: expect.objectContaining({ warningPct: 45 }),
+        }),
+      );
+    });
+
+    const warningRule = currentConfig.shutdownPolicy.rules.find(
+      (rule) => rule.id === DEFAULT_BATTERY_WARNING_RULE_ID,
+    );
+
+    expect(warningRule).toBeDefined();
+    expect(getNumericConditionValue(warningRule!.trigger, 'battery.chargePercent')).toBe(45);
+  });
+
+  it('disables the generated battery shutdown rule when battery shutdown is toggled off', async () => {
+    currentConfig = applyConfigPatch(currentConfig, {
+      battery: {
+        shutdownEnabled: true,
+        criticalShutdownAlertEnabled: false,
+      },
+    });
+    hoisted.currentConfig = currentConfig;
+
+    render(<SettingsPage />);
+
+    const shutdownToggle = screen.getByLabelText('settings.enableAutoShutdown');
+    expect(shutdownToggle).toBeChecked();
+
+    fireEvent.click(shutdownToggle);
+
+    await waitFor(() => {
+      expect(mockSettingsUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          battery: expect.objectContaining({ shutdownEnabled: false }),
+        }),
+      );
+    });
+
+    const shutdownRule = currentConfig.shutdownPolicy.rules.find(
+      (rule) => rule.id === DEFAULT_BATTERY_SHUTDOWN_RULE_ID,
+    );
+
+    expect(shutdownRule).toBeDefined();
+    expect(shutdownRule!.enabled).toBe(false);
+  });
+
+  it('warns before switching to advanced mode and preserves the generated simple rules', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+
+    renderPolicySection(onSave);
+
+    fireEvent.change(screen.getByLabelText('settings.shutdownPolicyMode'), {
+      target: { value: 'advanced' },
+    });
+
+    expect(confirmSpy).toHaveBeenCalledWith(
+      'Switching to advanced mode keeps the generated simple rules and lets you edit them directly.',
+    );
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mode: 'advanced',
+          rules: expect.any(Array),
+        }),
+      );
+    });
+
+    const savedPolicy = onSave.mock.calls[0][0] as AppConfig['shutdownPolicy'];
+    expect(savedPolicy.rules.map((rule) => rule.id)).toEqual(
+      currentConfig.shutdownPolicy.rules.map((rule) => rule.id),
+    );
+  });
+
+  it('shows matched and unmatched simulator results with explanations for synthetic input', async () => {
+    renderPolicySection();
+
+    fireEvent.change(screen.getByLabelText('settings.policySimulatorCharge'), {
+      target: { value: '15' },
+    });
+
+    expect(
+      await screen.findByText(
+        'Rule Shutdown when battery is critically low while on battery (default-battery-shutdown) matched and will show a critical alert.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText('settings.policySimulatorMatched').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('settings.policySimulatorNotMatched').length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/^PASS /).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/^FAIL /).length).toBeGreaterThan(0);
+  });
+
+  it('preserves all trigger leaves when editing the default communication-loss rule', async () => {
+    currentConfig = {
+      ...currentConfig,
+      shutdownPolicy: {
+        ...currentConfig.shutdownPolicy,
+        mode: 'advanced',
+      },
+    };
+
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    renderPolicySection(onSave);
+
+    fireEvent.click(screen.getByRole('button', {
+      name: /Shutdown if communication is lost while previously on battery/i,
+    }));
+    fireEvent.change(await screen.findByLabelText('settings.policyValue'), {
+      target: { value: '65' },
+    });
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalled();
+    });
+
+    const savedPolicy = onSave.mock.calls.at(-1)?.[0] as AppConfig['shutdownPolicy'];
+    const communicationRule = savedPolicy.rules.find(
+      (rule) => rule.id === DEFAULT_COMMUNICATION_LOSS_RULE_ID,
+    );
+
+    expect(communicationRule?.trigger).toEqual({
+      all: [
+        {
+          field: 'state.secondsOnBattery',
+          op: 'gte',
+          value: 65,
+        },
+        {
+          field: 'connection.secondsSinceLastSuccessfulPoll',
+          op: 'gte',
+          value: 300,
+        },
+      ],
+    });
+  });
+
+  it('renders decision history entries returned from the mocked IPC bridge', async () => {
+    mockDecisionLog = [
+      {
+        id: 'decision-1',
+        timestampIso: '2026-05-14T12:00:00.000Z',
+        event: 'decision',
+        decision: {
+          type: 'startShutdownCountdown',
+          ruleId: 'default-battery-shutdown',
+          countdownSeconds: 45,
+          method: 'sleep',
+          cancelWhen: null,
+        },
+        ruleId: 'default-battery-shutdown',
+        summary: 'Battery countdown started',
+        conditionExplanation: ['PASS Battery rule matched'],
+        context: {
+          statusTokens: ['OB', 'LB'],
+          batteryChargePercent: 19,
+          runtimeSeconds: 180,
+          connectionState: 'connected',
+          secondsSinceLastSuccessfulPoll: 0,
+          secondsOnBattery: 120,
+        },
+      },
+    ];
+
+    renderPolicySection();
+
+    expect(await screen.findByText('Battery countdown started')).toBeInTheDocument();
+    expect(screen.getByText('decision')).toBeInTheDocument();
+    expect(screen.getAllByText(/default-battery-shutdown/).length).toBeGreaterThan(0);
+  });
+
+  it('blocks invalid threshold saves at the UI layer with a visible error', async () => {
+    render(<SettingsPage />);
+
+    const warningInput = screen.getByLabelText('settings.warningPct');
+    fireEvent.change(warningInput, { target: { value: '10' } });
+    fireEvent.blur(warningInput);
+
+    expect(mockSettingsUpdate).not.toHaveBeenCalled();
+    expect(
+      await screen.findByText('Shutdown % must be lower than Warning %.'),
+    ).toBeInTheDocument();
+  });
+});
+
+function renderPolicySection(onSave = vi.fn().mockResolvedValue(undefined)) {
+  return render(
+    <ShutdownPolicySettingsSection
+      config={currentConfig}
+      batterySettings={currentConfig.battery}
+      fsdSettings={currentConfig.fsd}
+      onSave={onSave}
+    />,
+  );
+}

--- a/src/renderer/features/shutdownPolicy/ShutdownPolicySettingsSection.tsx
+++ b/src/renderer/features/shutdownPolicy/ShutdownPolicySettingsSection.tsx
@@ -220,6 +220,18 @@ export function ShutdownPolicySettingsSection({
                 return;
               }
 
+              if (
+                policy.mode === 'simple' &&
+                !window.confirm(
+                  t(
+                    'settings.shutdownPolicyAdvancedWarning',
+                    'Switching to advanced mode keeps the generated simple rules and lets you edit them directly.',
+                  ),
+                )
+              ) {
+                return;
+              }
+
               void savePolicy({
                 ...policy,
                 mode: 'advanced',
@@ -890,7 +902,8 @@ function PolicyRuleEditor({
                 const nextOperator =
                   POLICY_FIELD_METADATA[field].supportedOperators[0];
                 onUpdate({
-                  trigger: createEditableTrigger(
+                  trigger: updateEditableTrigger(
+                    rule.trigger,
                     field,
                     nextOperator,
                     defaultValueForField(field),
@@ -917,7 +930,8 @@ function PolicyRuleEditor({
               onChange={(event) => {
                 const operator = event.target.value as PolicyOperator;
                 onUpdate({
-                  trigger: createEditableTrigger(
+                  trigger: updateEditableTrigger(
+                    rule.trigger,
                     editableCondition.field,
                     operator,
                     editableCondition.value,
@@ -944,7 +958,8 @@ function PolicyRuleEditor({
               value={String(editableCondition.value ?? '')}
               onChange={(event) => {
                 onUpdate({
-                  trigger: createEditableTrigger(
+                  trigger: updateEditableTrigger(
+                    rule.trigger,
                     editableCondition.field,
                     editableCondition.operator,
                     parseConditionValue(
@@ -963,7 +978,8 @@ function PolicyRuleEditor({
             checked={editableCondition.requireOnBattery}
             onChange={(event) =>
               onUpdate({
-                trigger: createEditableTrigger(
+                trigger: updateEditableTrigger(
+                  rule.trigger,
                   editableCondition.field,
                   editableCondition.operator,
                   editableCondition.value,
@@ -1153,10 +1169,7 @@ function createEditableTrigger(
   value: string | number | boolean | undefined,
   requireOnBattery: boolean,
 ): PolicyCondition {
-  const leaf: PolicyCondition =
-    operator === 'exists' || operator === 'notExists'
-      ? { field, op: operator }
-      : { field, op: operator, value };
+  const leaf = createEditableLeaf(field, operator, value);
 
   if (!requireOnBattery) {
     return leaf;
@@ -1168,6 +1181,23 @@ function createEditableTrigger(
       leaf,
     ],
   };
+}
+
+function updateEditableTrigger(
+  originalCondition: PolicyCondition,
+  field: PolicyField,
+  operator: PolicyOperator,
+  value: string | number | boolean | undefined,
+  requireOnBattery: boolean,
+): PolicyCondition {
+  const nextLeaf = createEditableLeaf(field, operator, value);
+  const baseCondition = stripOnBatteryRequirement(originalCondition) ?? nextLeaf;
+  const [updatedCondition, replaced] = replaceFirstEditableLeaf(baseCondition, nextLeaf);
+  const nextCondition = replaced ? updatedCondition : nextLeaf;
+
+  return requireOnBattery
+    ? ensureOnBatteryRequirement(nextCondition)
+    : nextCondition;
 }
 
 function conditionIncludesOnBattery(condition: PolicyCondition): boolean {
@@ -1212,6 +1242,140 @@ function findFirstEditableLeaf(
   }
 
   return condition;
+}
+
+function createEditableLeaf(
+  field: PolicyField,
+  operator: PolicyOperator,
+  value: string | number | boolean | undefined,
+): PolicyCondition {
+  return operator === 'exists' || operator === 'notExists'
+    ? { field, op: operator }
+    : { field, op: operator, value };
+}
+
+function replaceFirstEditableLeaf(
+  condition: PolicyCondition,
+  nextLeaf: PolicyCondition,
+): [PolicyCondition, boolean] {
+  if ('all' in condition) {
+    let replaced = false;
+    return [
+      {
+        all: condition.all.map((child) => {
+          if (replaced) {
+            return child;
+          }
+
+          const [nextChild, childReplaced] = replaceFirstEditableLeaf(child, nextLeaf);
+          replaced = childReplaced;
+          return nextChild;
+        }),
+      },
+      replaced,
+    ];
+  }
+
+  if ('any' in condition) {
+    let replaced = false;
+    return [
+      {
+        any: condition.any.map((child) => {
+          if (replaced) {
+            return child;
+          }
+
+          const [nextChild, childReplaced] = replaceFirstEditableLeaf(child, nextLeaf);
+          replaced = childReplaced;
+          return nextChild;
+        }),
+      },
+      replaced,
+    ];
+  }
+
+  if ('not' in condition) {
+    const [nextCondition, replaced] = replaceFirstEditableLeaf(condition.not, nextLeaf);
+    return [{ not: nextCondition }, replaced];
+  }
+
+  return isOnBatteryRequirementLeaf(condition)
+    ? [condition, false]
+    : [nextLeaf, true];
+}
+
+function ensureOnBatteryRequirement(condition: PolicyCondition): PolicyCondition {
+  if (conditionIncludesOnBattery(condition)) {
+    return condition;
+  }
+
+  if ('all' in condition) {
+    return {
+      all: [onBatteryRequirement(), ...condition.all],
+    };
+  }
+
+  return {
+    all: [onBatteryRequirement(), condition],
+  };
+}
+
+function stripOnBatteryRequirement(condition: PolicyCondition): PolicyCondition | null {
+  if ('all' in condition) {
+    const children = condition.all
+      .map((child) => stripOnBatteryRequirement(child))
+      .filter((child): child is PolicyCondition => child !== null);
+    return simplifyConditionGroup('all', children);
+  }
+
+  if ('any' in condition) {
+    const children = condition.any
+      .map((child) => stripOnBatteryRequirement(child))
+      .filter((child): child is PolicyCondition => child !== null);
+    return simplifyConditionGroup('any', children);
+  }
+
+  if ('not' in condition) {
+    const nextCondition = stripOnBatteryRequirement(condition.not);
+    return nextCondition ? { not: nextCondition } : null;
+  }
+
+  return isOnBatteryRequirementLeaf(condition) ? null : condition;
+}
+
+function simplifyConditionGroup(
+  kind: 'all' | 'any',
+  children: PolicyCondition[],
+): PolicyCondition | null {
+  if (children.length === 0) {
+    return null;
+  }
+
+  if (children.length === 1) {
+    return children[0];
+  }
+
+  return kind === 'all'
+    ? { all: children }
+    : { any: children };
+}
+
+function isOnBatteryRequirementLeaf(
+  condition: Extract<PolicyCondition, { field: PolicyField; op: PolicyOperator }>,
+): boolean {
+  return (
+    condition.field === 'ups.onBattery' &&
+    condition.op === 'eq' &&
+    condition.value === true
+  );
+}
+
+function onBatteryRequirement(): PolicyCondition {
+  return {
+    field: 'ups.onBattery',
+    op: 'eq',
+    value: true,
+  };
 }
 
 function parseConditionValue(

--- a/src/shared/shutdownPolicy/defaultPolicies.test.ts
+++ b/src/shared/shutdownPolicy/defaultPolicies.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { shutdownPolicySchema } from '../../main/shutdown/schema/shutdownPolicySchema';
+import {
+  createRuntimeRemainingPolicy,
+  createSimpleShutdownPolicyConfig,
+  DEFAULT_BATTERY_SHUTDOWN_RULE_ID,
+  DEFAULT_BATTERY_WARNING_RULE_ID,
+  DEFAULT_COMMUNICATION_LOSS_RULE_ID,
+  DEFAULT_FSD_SHUTDOWN_RULE_ID,
+} from './defaultPolicies';
+
+const legacyBattery = {
+  warningPct: 40,
+  shutdownPct: 20,
+  warningToastEnabled: true,
+  shutdownEnabled: true,
+  criticalAlertEnabled: true,
+  criticalShutdownAlertEnabled: true,
+  shutdownCountdownSeconds: 60,
+  shutdownMethod: 'shutdown' as const,
+};
+
+const legacyFsd = {
+  shutdownEnabled: true,
+  shutdownDelaySeconds: 30,
+  shutdownMethod: 'shutdown' as const,
+  overlayEnabled: true,
+};
+
+describe('default shutdown policies', () => {
+  it('uses Phase 1 hold defaults for generated simple policies', () => {
+    const config = createSimpleShutdownPolicyConfig({
+      battery: legacyBattery,
+      fsd: legacyFsd,
+    });
+    const holdByRuleId = Object.fromEntries(
+      config.rules.map((rule) => [rule.id, rule.holdForSeconds]),
+    );
+
+    expect(config.safety.requireHoldForShutdownSeconds).toBe(5);
+    expect(holdByRuleId[DEFAULT_BATTERY_WARNING_RULE_ID]).toBe(5);
+    expect(holdByRuleId[DEFAULT_BATTERY_SHUTDOWN_RULE_ID]).toBe(10);
+    expect(holdByRuleId[DEFAULT_FSD_SHUTDOWN_RULE_ID]).toBe(3);
+    expect(holdByRuleId[DEFAULT_COMMUNICATION_LOSS_RULE_ID]).toBe(5);
+    expect(shutdownPolicySchema.safeParse(config).success).toBe(true);
+  });
+
+  it('uses a 10-second hold for runtime remaining defaults', () => {
+    expect(createRuntimeRemainingPolicy().holdForSeconds).toBe(10);
+  });
+});

--- a/src/shared/shutdownPolicy/defaultPolicies.ts
+++ b/src/shared/shutdownPolicy/defaultPolicies.ts
@@ -4,6 +4,7 @@ import type {
   ShutdownPolicyConfig,
   ShutdownPolicyRule,
 } from './types';
+import { DEFAULT_SHUTDOWN_POLICY_SAFETY } from './constants';
 
 export const DEFAULT_BATTERY_WARNING_RULE_ID = 'default-battery-warning';
 export const DEFAULT_BATTERY_SHUTDOWN_RULE_ID = 'default-battery-shutdown';
@@ -71,7 +72,7 @@ export function createBatteryWarningPolicy(
         lowBatteryPercentOrTokenCondition(battery.warningPct),
       ],
     },
-    holdForSeconds: 0,
+    holdForSeconds: 5,
     action: {
       type: 'showWarning',
     },
@@ -102,7 +103,7 @@ export function createBatteryShutdownPolicy(
         lowBatteryPercentOrTokenCondition(battery.shutdownPct),
       ],
     },
-    holdForSeconds: 0,
+    holdForSeconds: 10,
     action,
     cancelWhen: {
       any: [
@@ -151,7 +152,7 @@ export function createFsdShutdownPolicy(
       op: 'eq',
       value: true,
     },
-    holdForSeconds: 0,
+    holdForSeconds: 3,
     action,
     cancelWhen: null,
     cooldownSeconds: 0,
@@ -210,7 +211,7 @@ export function createCommunicationLossPolicy(
         },
       ],
     },
-    holdForSeconds: 0,
+    holdForSeconds: DEFAULT_SHUTDOWN_POLICY_SAFETY.requireHoldForShutdownSeconds,
     action: {
       type: 'startShutdownCountdown',
       countdownSeconds,
@@ -249,7 +250,7 @@ export function createRuntimeRemainingPolicy(
         },
       ],
     },
-    holdForSeconds: 0,
+    holdForSeconds: 10,
     action: {
       type: 'startShutdownCountdown',
       countdownSeconds,
@@ -276,7 +277,8 @@ export function createSimpleShutdownPolicyConfig(
     version: 1,
     mode: input.mode ?? existing?.mode ?? 'simple',
     safety: {
-      requireHoldForShutdownSeconds: 0,
+      requireHoldForShutdownSeconds:
+        DEFAULT_SHUTDOWN_POLICY_SAFETY.requireHoldForShutdownSeconds,
       maxCountdownSeconds: existing?.safety.maxCountdownSeconds ?? 300,
       allowImmediateShutdown:
         existing?.safety.allowImmediateShutdown === true ||

--- a/src/shared/shutdownPolicy/ordering.ts
+++ b/src/shared/shutdownPolicy/ordering.ts
@@ -1,0 +1,52 @@
+import type { ShutdownPolicyRule, ShutdownPolicySeverity } from './types';
+
+export type ShutdownPolicyRankTarget = {
+  priority: number;
+  severity: ShutdownPolicySeverity;
+  order: number;
+};
+
+export const SEVERITY_RANK: Record<ShutdownPolicySeverity, number> = {
+  info: 0,
+  warning: 1,
+  critical: 2,
+  forced: 3,
+};
+
+export function compareShutdownPolicyRank(
+  left: ShutdownPolicyRankTarget,
+  right: ShutdownPolicyRankTarget,
+): number {
+  if (left.priority !== right.priority) {
+    return left.priority - right.priority;
+  }
+
+  const leftSeverity = SEVERITY_RANK[left.severity];
+  const rightSeverity = SEVERITY_RANK[right.severity];
+  if (leftSeverity !== rightSeverity) {
+    return leftSeverity - rightSeverity;
+  }
+
+  if (left.order !== right.order) {
+    return right.order - left.order;
+  }
+
+  return 0;
+}
+
+export function compareShutdownPolicyRuleResults<
+  T extends { rule: Pick<ShutdownPolicyRule, 'priority' | 'severity'>; order: number },
+>(left: T, right: T): number {
+  return compareShutdownPolicyRank(
+    {
+      priority: left.rule.priority,
+      severity: left.rule.severity,
+      order: left.order,
+    },
+    {
+      priority: right.rule.priority,
+      severity: right.rule.severity,
+      order: right.order,
+    },
+  );
+}

--- a/src/shared/shutdownPolicy/simulator.test.ts
+++ b/src/shared/shutdownPolicy/simulator.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { ShutdownPolicyEngine } from '../../main/shutdown/ShutdownPolicyEngine';
 import { explainDecision, flattenConditionExplanation } from './explain';
 import { simulateShutdownPolicy } from './simulator';
 import type {
@@ -8,6 +9,51 @@ import type {
 } from './types';
 
 describe('shutdown policy simulator and explanations', () => {
+  it('returns no decision for an empty policy', () => {
+    const result = simulateShutdownPolicy(makeConfig([]), makeContext());
+
+    expect(result.decision).toEqual({ type: 'none' });
+    expect(result.selectedRule).toBeUndefined();
+    expect(result.ruleResults).toEqual([]);
+  });
+
+  it('matches the engine rule selection when equal-priority rules differ only by severity', () => {
+    const warningRule = makeRule({
+      id: 'warning',
+      name: 'Battery warning',
+      priority: 100,
+      severity: 'warning',
+      trigger: { field: 'ups.onBattery', op: 'eq', value: true },
+      action: { type: 'showWarning' },
+    });
+    const criticalRule = makeRule({
+      id: 'critical',
+      name: 'Battery critical',
+      priority: 100,
+      severity: 'critical',
+      trigger: { field: 'ups.onBattery', op: 'eq', value: true },
+      action: {
+        type: 'startShutdownCountdown',
+        countdownSeconds: 45,
+        method: 'shutdown',
+      },
+    });
+    const config = makeConfig([warningRule, criticalRule]);
+    const context = makeContext();
+
+    const simulatorResult = simulateShutdownPolicy(config, context);
+    const engineResult = new ShutdownPolicyEngine(config).evaluate(context);
+
+    expect(simulatorResult.selectedRule?.id).toBe('critical');
+    expect(engineResult).toMatchObject({
+      type: 'startShutdownCountdown',
+      ruleId: 'critical',
+    });
+    expect(
+      engineResult.type === 'none' ? undefined : engineResult.ruleId,
+    ).toBe(simulatorResult.selectedRule?.id);
+  });
+
   it('selects the highest ranked matching rule and explains the decision', () => {
     const shutdownRule = makeRule({
       id: 'shutdown',
@@ -71,6 +117,52 @@ describe('shutdown policy simulator and explanations', () => {
         expect.stringContaining('battery.chargePercent lte did not match'),
       ]),
     );
+  });
+
+  it('creates showCriticalAlert, shutdownNow, and explicit cancel decisions from matching rules', () => {
+    const alertResult = simulateShutdownPolicy(
+      makeConfig([
+        makeRule({
+          id: 'critical-alert',
+          action: { type: 'showCriticalAlert', message: 'critical' },
+        }),
+      ]),
+      makeContext(),
+    );
+    const shutdownNowResult = simulateShutdownPolicy(
+      makeConfig([
+        makeRule({
+          id: 'shutdown-now',
+          action: { type: 'shutdownNow', method: 'sleep' },
+        }),
+      ]),
+      makeContext(),
+    );
+    const cancelResult = simulateShutdownPolicy(
+      makeConfig([
+        makeRule({
+          id: 'cancel-now',
+          action: { type: 'cancelShutdownCountdown' },
+        }),
+      ]),
+      makeContext(),
+    );
+
+    expect(alertResult.decision).toEqual({
+      type: 'showCriticalAlert',
+      ruleId: 'critical-alert',
+      message: 'critical',
+    });
+    expect(shutdownNowResult.decision).toEqual({
+      type: 'shutdownNow',
+      ruleId: 'shutdown-now',
+      method: 'sleep',
+    });
+    expect(cancelResult.decision).toEqual({
+      type: 'cancelShutdownCountdown',
+      ruleId: 'cancel-now',
+      reason: 'Rule action requested countdown cancellation',
+    });
   });
 
   it('lets an equal-rank earlier shutdown rule override active countdown cancellation', () => {
@@ -203,6 +295,130 @@ describe('shutdown policy simulator and explanations', () => {
       expect(result.ruleResults[0].matched).toBe(false);
       expect(result.ruleResults[0].skippedReason).toBe('hold');
       expect(result.ruleResults[0].condition.reason).toContain('0s/10s');
+    });
+
+    it.each([
+      {
+        name: 'low-battery status duration',
+        trigger: { field: 'ups.lowBattery', op: 'eq', value: true },
+        state: {
+          secondsOnBattery: 120,
+          secondsOnline: 0,
+          secondsLowBattery: 40,
+          secondsInFsd: 0,
+        },
+        ups: {
+          online: false,
+          onBattery: true,
+          lowBattery: true,
+          fsd: false,
+          statusTokens: ['OB', 'LB'],
+        },
+      },
+      {
+        name: 'fsd status duration',
+        trigger: { field: 'ups.fsd', op: 'eq', value: true },
+        state: {
+          secondsOnBattery: 120,
+          secondsOnline: 0,
+          secondsLowBattery: 0,
+          secondsInFsd: 45,
+        },
+        ups: {
+          online: false,
+          onBattery: true,
+          lowBattery: false,
+          fsd: true,
+          statusTokens: ['OB', 'FSD'],
+        },
+      },
+      {
+        name: 'online status duration',
+        trigger: { field: 'ups.online', op: 'eq', value: true },
+        state: {
+          secondsOnBattery: 0,
+          secondsOnline: 35,
+          secondsLowBattery: 0,
+          secondsInFsd: 0,
+        },
+        ups: {
+          online: true,
+          onBattery: false,
+          lowBattery: false,
+          fsd: false,
+          statusTokens: ['OL'],
+        },
+      },
+      {
+        name: 'state.secondsLowBattery numeric field duration',
+        trigger: { field: 'state.secondsLowBattery', op: 'gte', value: 10 },
+        state: {
+          secondsOnBattery: 120,
+          secondsOnline: 0,
+          secondsLowBattery: 25,
+          secondsInFsd: 0,
+        },
+        ups: {
+          online: false,
+          onBattery: true,
+          lowBattery: true,
+          fsd: false,
+          statusTokens: ['OB', 'LB'],
+        },
+      },
+      {
+        name: 'state.secondsInFsd numeric field duration',
+        trigger: { field: 'state.secondsInFsd', op: 'gte', value: 10 },
+        state: {
+          secondsOnBattery: 120,
+          secondsOnline: 0,
+          secondsLowBattery: 0,
+          secondsInFsd: 25,
+        },
+        ups: {
+          online: false,
+          onBattery: true,
+          lowBattery: false,
+          fsd: true,
+          statusTokens: ['OB', 'FSD'],
+        },
+      },
+      {
+        name: 'state.secondsOnline numeric field duration',
+        trigger: { field: 'state.secondsOnline', op: 'gte', value: 10 },
+        state: {
+          secondsOnBattery: 0,
+          secondsOnline: 25,
+          secondsLowBattery: 0,
+          secondsInFsd: 0,
+        },
+        ups: {
+          online: true,
+          onBattery: false,
+          lowBattery: false,
+          fsd: false,
+          statusTokens: ['OL'],
+        },
+      },
+    ] satisfies Array<{
+      name: string;
+      trigger: ShutdownPolicyRule['trigger'];
+      state: ShutdownPolicyContext['state'];
+      ups: ShutdownPolicyContext['ups'];
+    }>)('uses $name to satisfy hold-time inference', ({ trigger, state, ups }) => {
+      const result = simulateShutdownPolicy(
+        makeConfig([
+          makeRule({
+            trigger,
+            holdForSeconds: 20,
+            action: { type: 'showWarning' },
+          }),
+        ]),
+        makeContext({ state, ups }),
+      );
+
+      expect(result.ruleResults[0].matched).toBe(true);
+      expect(result.ruleResults[0].skippedReason).toBeUndefined();
     });
   });
 

--- a/src/shared/shutdownPolicy/simulator.ts
+++ b/src/shared/shutdownPolicy/simulator.ts
@@ -6,6 +6,7 @@ import type {
   ShutdownPolicyRule,
 } from './types';
 import { evaluatePolicyCondition } from './evaluation';
+import { compareShutdownPolicyRuleResults } from './ordering';
 
 export type ShutdownPolicySimulationRuleResult = {
   rule: ShutdownPolicyRule;
@@ -19,13 +20,6 @@ export type ShutdownPolicySimulationResult = {
   decision: ShutdownPolicyDecision;
   selectedRule?: ShutdownPolicyRule;
   ruleResults: ShutdownPolicySimulationRuleResult[];
-};
-
-const severityRank = {
-  info: 0,
-  warning: 1,
-  critical: 2,
-  forced: 3,
 };
 
 export function simulateShutdownPolicy(
@@ -78,7 +72,15 @@ export function simulateShutdownPolicy(
 
   const selected = ruleResults
     .filter((result) => result.matched)
-    .sort(compareRuleResults)[0];
+    .reduce<ShutdownPolicySimulationRuleResult | undefined>((best, result) => {
+      if (!best) {
+        return result;
+      }
+
+      return compareShutdownPolicyRuleResults(result, best) > 0
+        ? result
+        : best;
+    }, undefined);
   const cancellation = simulateActiveCountdownCancellation(
     config,
     context,
@@ -129,12 +131,12 @@ function simulateActiveCountdownCancellation(
   if (
     selected &&
     isShutdownAction(selected.rule) &&
-    compareRuleResults(selected, {
+    compareShutdownPolicyRuleResults(selected, {
       rule: activeRule,
       order: activeRuleOrder,
       matched: true,
       condition: cancelResult,
-    }) < 0
+    }) > 0
   ) {
     return null;
   }
@@ -152,23 +154,6 @@ function simulateActiveCountdownCancellation(
         : r,
     ),
   };
-}
-
-function compareRuleResults(
-  left: ShutdownPolicySimulationRuleResult,
-  right: ShutdownPolicySimulationRuleResult,
-): number {
-  if (left.rule.priority !== right.rule.priority) {
-    return right.rule.priority - left.rule.priority;
-  }
-
-  const severityDiff =
-    severityRank[right.rule.severity] - severityRank[left.rule.severity];
-  if (severityDiff !== 0) {
-    return severityDiff;
-  }
-
-  return left.order - right.order;
 }
 
 function createDecision(rule: ShutdownPolicyRule): ShutdownPolicyDecision {


### PR DESCRIPTION
- FSD shutdowns are now unconditionally irrevocable. cancelPolicyCountdown previously checked ruleId === DEFAULT_FSD_SHUTDOWN_RULE_ID, which allowed a user-authored cancelShutdownCountdown
   rule emits the cancellation.

- When the engine cancels an active countdown via its cancelWhen condition, the cooldown for the cancelled rule is now recorded before returning. Previously lastDecisionAt/cooldownUntil were never
- 
  set on the cancelWhen path, so a still-matching trigger immediately re-armed the countdown on the next tick.
- handleConfigUpdated previously cleared activeCountdownRuleId and appliedRuleIds unconditionally, leaving an active FSD overlay visible while the engine and service had forgotten which rule
  owned it. This widened the L2-F1 attack surface after any settings save. FSD countdown state is now captured before the swap and restored on the new engine instance when fsdShutdownCommitted is true.

- Phase 1 hold defaults — Default simple policies now ship with per-rule hold times (warning: 5 s, battery shutdown: 10 s, FSD: 3 s, comms-loss: 5 s; safety floor: 5 s) to prevent spurious shutdowns on
  transient UPS state flickers.

- Schema-level defence in depth — shutdownPolicySchema now rejects cancelShutdownCountdown rules authored by users when allowFsdAutoCancel is false, providing a parse-time barrier independent of the runtime
  service guard.